### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.66</version> <!-- jenkins core 2.200 requires 4.0 or higher -->
+        <version>4.72</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
## Test with Java 21

Java 21 will release Sep 19, 2023.  The Jenkins project would like to support Java 21 soon after it releases.  We're testing Jenkins core and Jenkins plugins with Java 21 pre-release builds so that we're better prepared for the final release.  

- Use plugin pom 4.72 (needed for Java 21 testing)
- Test with Java 21

### Testing done

Confirmed that automated tests pass on Linux with Java 11, Java 17, and Java 21.

Rely on ci.jenkins.io to confirm automated tests pass on Windows.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
