### PR TITLE
[JENKINS-71884] Fix simple queue setup for 2.414.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>1.4.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.414.1</jenkins.version>
         <useBeta>true</useBeta> <!--can be deleted when manage permission does not require it anymore. https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/Jenkins.java -->
     </properties>
     <name>Simple Queue Plugin</name>

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
@@ -1,29 +1,52 @@
 package cz.mendelu.xotradov;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionComponent;
+import hudson.model.View;
 import hudson.widgets.Widget;
-
-import java.util.logging.Logger;
+import java.util.Collection;
+import java.util.List;
 import jenkins.ExtensionFilter;
 import jenkins.widgets.BuildQueueWidget;
+import jenkins.widgets.WidgetFactory;
+
 
 /**
  * SimpleQueueWidget replaces the default BuildQueueWidget and adds arrows to each buildable item.
  */
-@SuppressWarnings("unused") //justification: used because of the @Extension below
-@Extension(ordinal=199)
 public class SimpleQueueWidget extends Widget {
-    private final static Logger logger = Logger.getLogger(SimpleQueueWidget.class.getName());
+    @SuppressWarnings("unused") // jelly
     public static String getMoveTypeName(){return MoveAction.MOVE_TYPE_PARAM_NAME;}
+    @SuppressWarnings("unused") // jelly
     public static String getItemIdName(){return MoveAction.ITEM_ID_PARAM_NAME;}
+    @SuppressWarnings("unused") // jelly
     public static String getViewNameParamName(){return MoveAction.VIEW_NAME_PARAM_NAME;}
+
+    @Extension(ordinal = 100)
+    public static final class ViewFactoryImpl extends WidgetFactory<View, SimpleQueueWidget> {
+        @Override
+        public Class<View> type() {
+            return View.class;
+        }
+
+        @Override
+        public Class<SimpleQueueWidget> widgetType() {
+            return SimpleQueueWidget.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<SimpleQueueWidget> createFor(@NonNull View target) {
+            return List.of(new SimpleQueueWidget());
+        }
+    }
 
     @Extension
     public static final class RemoveDefaultQueueWidget extends ExtensionFilter {
         @Override
         public <T> boolean allows(Class<T> type, ExtensionComponent<T> component) {
-            return Widget.class != type || !BuildQueueWidget.class.isInstance(component.getInstance());
+            return WidgetFactory.class != type || !BuildQueueWidget.ViewFactoryImpl.class.isInstance(component.getInstance());
         }
     }
 }

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest.java
@@ -1,31 +1,17 @@
 package cz.mendelu.xotradov.test.basic;
 
+import static org.junit.Assert.assertTrue;
+
 import cz.mendelu.xotradov.SimpleQueueWidget;
-import cz.mendelu.xotradov.test.TestHelper;
-import hudson.widgets.Widget;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import java.util.logging.Logger;
-
-import static org.junit.Assert.*;
-
 public class BasicTest {
-    public static Logger logger = Logger.getLogger(BasicTest.class.getName());
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
     @Test
-    public void widgetPresenceTest(){
-        boolean presence = false;
-        for (Widget widget1: jenkinsRule.jenkins.getWidgets()){
-            if (widget1 instanceof SimpleQueueWidget) {
-                presence = true;
-                break;
-            }
-        }
-        assertTrue(presence);
+    public void widgetPresenceTest() {
+        assertTrue(jenkinsRule.jenkins.getPrimaryView().getWidgets().stream().anyMatch(SimpleQueueWidget.class::isInstance));
     }
-    }
+}


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-71884

This uses the new widget setup relying on `WidgetFactory` as well as fix the removal of default widget.

Only doing this in views, not in `ComputerSet` as the current queue widget needs rework to work in a different context.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
