### PR TITLE
Bumping jdk version to 21

### DIFF
--- a/.github/pull_request_template.md 
+++ b/.github/pull_request_template.md 
@@ -1,0 +1,5 @@
+### Submitter checklist
+- [ ] Ensure that the pull request title represents the desired changelog entry
+- [ ] Please describe what you did
+- [ ] Link to relevant issues in GitHub or Jira
+- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,5 @@
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,13 @@
     <version>1.4.8-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.414.1</jenkins.version>
+        <jenkins.version>2.426.1</jenkins.version>
         <useBeta>true</useBeta> <!--can be deleted when manage permission does not require it anymore. https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/Jenkins.java -->
+        <java.level>21</java.level>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.testRelease>21</maven.compiler.testRelease>
     </properties>
     <name>Simple Queue Plugin</name>
     <description>Enables to change queue order by simple up &amp; down arrow buttons. UI Queue Sorter.</description>
@@ -59,6 +64,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
      <reporting>
     </reporting>
 </project>


### PR DESCRIPTION
Bumping JDK to 21. Raising Jenkins version to 2.426.1 in preparation for test uplifting to JUnit5

### Testing done
Local run ok

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
