### PR TITLE
Bumped jenkins.base and plugin.parent to newest values

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'linux', jdk: 21],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>6.2138.v03274d462c13</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,8 +12,8 @@
     <version>1.4.10-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.426.1</jenkins.version>
-        <useBeta>true</useBeta> <!--can be deleted when manage permission does not require it anymore. https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/Jenkins.java -->
+        <jenkins.baseline>2.528</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
     <name>Simple Queue Plugin</name>
     <description>Enables to change queue order by simple up &amp; down arrow buttons. UI Queue Sorter.</description>

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-
 import hudson.model.Queue;
 import hudson.model.View;
 import hudson.model.queue.QueueSorter;

--- a/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
@@ -6,7 +6,6 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import java.util.logging.Logger;
 
-
 import hudson.Extension;
 import hudson.model.Queue;
 import hudson.model.RootAction;

--- a/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
@@ -6,6 +6,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.model.queue.QueueSorter;
@@ -48,6 +49,7 @@ public class UnsafeResetAction implements RootAction {
     }
 
     @Override
+    @CheckForNull
     public String getUrlName() {
         return "simpleQueueResetUnsafe";
     }

--- a/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
@@ -6,7 +6,6 @@ import org.kohsuke.stapler.StaplerResponse;
 import java.io.IOException;
 import java.util.logging.Logger;
 
-
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.model.queue.QueueSorter;

--- a/src/test/java/cz/mendelu/xotradov/UITest.java
+++ b/src/test/java/cz/mendelu/xotradov/UITest.java
@@ -28,7 +28,6 @@ public class UITest {
     }
 
     @Test
-    @Ignore("seems to be not supported in newer jenkins")
     public void HoverText() throws Exception {
         long maxTestTime = 30000;
         helper.fillQueueFor(maxTestTime);
@@ -37,13 +36,12 @@ public class UITest {
         HtmlPage page = jenkinsRule.createWebClient().goTo("");
         DomNode queueElement = page.getElementById("buildSimpleQueue");
         DomNode div = queueElement.getChildren().iterator().next().getNextSibling();
-        DomNode a = div.getFirstChild().getNextSibling().getFirstChild().getFirstChild().getFirstChild().getFirstChild();
+        DomNode a = div.getFirstChild().getFirstChild().getFirstChild().getFirstChild().getFirstChild();
         assertFalse(a.asXml().contains("WaitingFor"));
         assertTrue(a.asXml().contains("sec"));
     }
 
     @Test
-    @Ignore("seems to be not supported in newer jenkins")
     public void initWidgetTest() throws Exception {
         long maxTestTime = 30000;
         helper.fillQueueFor(maxTestTime);


### PR DESCRIPTION
Bumped to :
```
         <artifactId>plugin</artifactId>
-        <version>4.72</version>
+        <version>6.2138.v03274d462c13</version>
-        <jenkins.version>2.426.1</jenkins.version>
+        <jenkins.baseline>2.528</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
```
Removed `<useBeta>true</useBeta> `

Enabled and fixed
```
   public void HoverText() throws Exception {
   public void initWidgetTest() throws Exception {
```
Reintroduced `@checkfornull` at UnsafeResetAction.java


