### PR TITLE
[JENKINS-64705] update queue without form submission

### DIFF
--- a/docs_src/docs/CLI.md
+++ b/docs_src/docs/CLI.md
@@ -202,5 +202,11 @@ This is annoying, and PR to improve this is welcomed. However, such a cross-plug
 class-name/reflection work, or coordination with maintainers of those plugins.
 
 #### HTTP return value
-Unluckily, currently plugin always returns `302 Found` so you will not know if your call actually succeeded.
-This may change in the future, but is not planned at this time.
+The plugin returns status code `200` if the move was successful. Status code `404` is returned when the queue
+item was not found and `400` when the move type is invalid.
+The error responses contain a json body with more details, e.g.:
+```
+{
+  "message": "Queue item '1234' not found"
+}
+```

--- a/src/main/java/cz/mendelu/xotradov/MoveAction.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveAction.java
@@ -46,17 +46,19 @@ public class MoveAction extends MoveActionWorker implements RootAction  {
      */
     @RequirePOST
     public void doMove(final StaplerRequest request, final StaplerResponse response) {
-        Jenkins j;
-        if ((j = Jenkins.getInstanceOrNull()) != null) {
-            Queue queue = j.getQueue();
-            if (queue != null & j.hasPermission(PermissionHandler.SIMPLE_QUEUE_MOVE_PERMISSION)) {
-                moveImpl(request, queue, j);
-            }
+        Jenkins j = Jenkins.get();
+        if (!j.hasPermission(PermissionHandler.SIMPLE_QUEUE_MOVE_PERMISSION)) {
+            response.setStatus(StaplerResponse.SC_FORBIDDEN);
+            return;
         }
         try {
-            response.forwardToPreviousPage(request);
+            Queue queue = j.getQueue();
+            if (queue != null & j.hasPermission(PermissionHandler.SIMPLE_QUEUE_MOVE_PERMISSION)) {
+                moveImpl(request, response, queue, j);
+            }
         } catch (Exception e) {
             logger.warning(e.toString());
+            response.setStatus(StaplerResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -6,7 +6,10 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,6 +24,7 @@ import hudson.model.Queue;
 import hudson.model.View;
 import hudson.model.queue.QueueSorter;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 
 public class MoveActionWorker {
     protected static final Logger logger = Logger.getLogger(MoveActionWorker.class.getName());
@@ -30,7 +34,7 @@ public class MoveActionWorker {
     public static final String VIEW_NAME_PARAM_NAME = "viewName";
     protected boolean isSorterSet = false;
 
-    protected void moveImpl(StaplerRequest request, Queue queue, Jenkins j) {
+    protected void moveImpl(StaplerRequest request, StaplerResponse response, Queue queue, Jenkins j) throws IOException {
         try {
             String idParam = request.getParameter(ITEM_ID_PARAM_NAME);
             String idParamMode = request.getParameter(ITEM_ID_PARAM_MODE);
@@ -76,20 +80,37 @@ public class MoveActionWorker {
                     }
                 }
             }
-
-            MoveType moveType = MoveType.valueOf(request.getParameter(MOVE_TYPE_PARAM_NAME));
-            View view = j.getView(request.getParameter(VIEW_NAME_PARAM_NAME));
-            if (items != null && items.length > 0) {
-                move(queue, items, moveType, view);
-                Queue.getInstance().maintain();
-            } else {
-                logger.info("Wrong item id " + idParam + " (or not found in view " + request.getParameter(VIEW_NAME_PARAM_NAME) + ")");
+            if (items == null || items.length == 0) {
+                logger.info("Queue item with id '" + idParam + "' not found");
+                response.setStatus(StaplerResponse.SC_NOT_FOUND);
+                PrintWriter writer = response.getWriter();
+                JSONObject message = new JSONObject();
+                message.put("error", "Queue item with id '" + idParam + "' not found");
+                writer.println(message.toString(2));
+                return;
             }
-        } catch (IllegalArgumentException iae) {
-            logger.info("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME));
+
+            MoveType moveType = null;
+            try {
+                moveType = MoveType.valueOf(request.getParameter(MOVE_TYPE_PARAM_NAME));
+            } catch (IllegalArgumentException iae) {
+                logger.info("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME));
+                response.setStatus(StaplerResponse.SC_BAD_REQUEST);
+                PrintWriter writer = response.getWriter();
+                JSONObject message = new JSONObject();
+                message.put("error", "Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME));
+                writer.println(message.toString(2));
+                return;
+            }
+
+            View view = j.getView(request.getParameter(VIEW_NAME_PARAM_NAME));
+            move(queue, items, moveType, view);
+            Queue.getInstance().maintain();
+            response.setStatus(StaplerResponse.SC_OK);
         } catch (Exception ex) {
             logger.info("unable to simple-queue item " + request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(
                     Collectors.joining(","))).collect(Collectors.joining("; ")));
+            throw ex;
         }
     }
 

--- a/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
@@ -39,15 +39,13 @@ public class UnsafeMoveAction extends MoveActionWorker implements RootAction {
         if (!SimpleQueueConfig.getInstance().isEnableUnsafe()) {
             throw new IllegalArgumentException("Unsafe reset api attempted without being enabled");
         }
-        Jenkins j;
-        if ((j = Jenkins.getInstanceOrNull()) != null) {
-            Queue queue = j.getQueue();
-            moveImpl(request, queue, j);
-        }
+        Jenkins j = Jenkins.get();
         try {
-            response.forwardToPreviousPage(request);
+            Queue queue = j.getQueue();
+            if (queue != null & j.hasPermission(PermissionHandler.SIMPLE_QUEUE_MOVE_PERMISSION)) {
+                moveImpl(request, response, queue, j);
+            }
         } catch (Exception e) {
-            logger.warning(e.toString());
-        }
-    }
+            response.setStatus(StaplerResponse.SC_INTERNAL_SERVER_ERROR);
+        }    }
 }

--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
@@ -64,35 +64,34 @@
                             <td class="pane" align="center" valign="middle">
                               <div class="simple-queue-buttons">
                                   <j:if test="${filtered}">
-                                      <a class="post"
-                                         href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=TOP&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                      <a href="#" class="simple-move-link" data-move-type="TOP" data-item-id="${item.id}"
                                          tooltip="${%Move to top of the queue within the view.}"
                                          data-tooltip-append-to-parent="true">
                                           <l:icon src="symbol-arrow-top plugin-simple-queue" class="icon-sm"/>
                                       </a>
                                   </j:if>
-                                  <a class="post" href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=UP_FAST&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                  <a href="#" class="simple-move-link" data-move-type="UP_FAST" data-item-id="${item.id}"
                                      tooltip="${%Move to top of the queue.}"
                                      data-tooltip-append-to-parent="true">
                                       <l:icon src="symbol-arrow-up-fast plugin-simple-queue" class="icon-sm"/>
                                   </a>
-                                  <a class="post" href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=UP&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                  <a href="#" class="simple-move-link" data-move-type="UP" data-item-id="${item.id}"
                                      tooltip="${%Move up before the preceding queue item.}"
                                      data-tooltip-append-to-parent="true">
                                       <l:icon src="symbol-chevron-up" class="icon-sm"/>
                                   </a>
-                                  <a class="post" href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=DOWN&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                  <a href="#" class="simple-move-link" data-move-type="DOWN" data-item-id="${item.id}"
                                      tooltip="${%Move down after the following queue item.}"
                                      data-tooltip-append-to-parent="true">
                                       <l:icon src="symbol-chevron-down" class="icon-sm"/>
                                   </a>
-                                  <a class="post" href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=DOWN_FAST&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                  <a href="#" class="simple-move-link" data-move-type="DOWN_FAST" data-item-id="${item.id}"
                                      tooltip="${%Move to bottom of queue.}"
                                      data-tooltip-append-to-parent="true">
                                       <l:icon src="symbol-arrow-down-fast plugin-simple-queue" class="icon-sm"/>
                                   </a>
                                   <j:if test="${filtered}">
-                                      <a class="post" href="${rootURL}/simpleMove/move?${it.getMoveTypeName()}=BOTTOM&amp;${it.getItemIdName()}=${item.id}&amp;${it.getViewNameParamName()}=${viewName}"
+                                      <a href="#" class="simple-move-link" data-move-type="BOTTOM" data-item-id="${item.id}"
                                          tooltip="${%Move to bottom of the queue within the view.}"
                                          data-tooltip-append-to-parent="true">
                                         <l:icon src="symbol-arrow-bottom plugin-simple-queue" class="icon-sm"/>
@@ -115,7 +114,8 @@
     </l:pane>
     <!-- schedule updates only for the full page reload-->
     <j:if test="${ajax==null and h.hasPermission(app.READ)}">
-      <div class="widget-refresh-reference" data-id="buildSimpleQueue" data-url="${rootURL}/${it.url}ajax"/>
+      <div id="simple-queue-data-holder" class="widget-refresh-reference" data-id="buildSimpleQueue" data-url="${rootURL}/${it.url}ajax"
+           data-view-name="${viewName}" data-view-owner="${viewOwner}" data-move-url="${rootURL}/simpleMove/move"/>
       <st:adjunct includes="lib.hudson.widget-refresh"/>
       <st:adjunct includes="cz.mendelu.xotradov.SimpleQueueWidget.simple-queue-widget"/>
       <st:adjunct includes="lib.form.link.link"/>

--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/simple-queue-widget.js
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/simple-queue-widget.js
@@ -1,0 +1,26 @@
+Behaviour.specify(".simple-move-link", "simple-queue-widget", 0, function (element) {
+    const dataHolder = document.getElementById("simple-queue-data-holder");
+    const url = dataHolder.dataset.moveUrl;
+    const viewOwner = dataHolder.dataset.viewOwner;
+    const viewName = dataHolder.dataset.viewName;
+    element.addEventListener("click", function (event) {
+        event.preventDefault();
+        const params = new URLSearchParams({
+            itemId: element.dataset.itemId,
+            viewOwner: viewOwner,
+            viewName: viewName,
+            moveType: element.dataset.moveType
+        });
+        fetch(url + "?" + params, {
+            method: "POST",
+            cache: "no-cache",
+            headers: crumb.wrap({
+                "Content-Type": "application/x-www-form-urlencoded",
+            })
+        }).then((response) => {
+            if (!response.ok) {
+                console.warn(`SimpleQueueWidget move request failed with status ${response.status}`);
+            }
+        }).catch((error) => console.warn(`SimpleQueueWidget move request failed: ${error}`));
+    });
+});

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import static cz.mendelu.xotradov.MoveAction.ITEM_ID_PARAM_NAME;
 import static cz.mendelu.xotradov.MoveAction.MOVE_TYPE_PARAM_NAME;
+import static cz.mendelu.xotradov.MoveAction.VIEW_NAME_PARAM_NAME;
 
 import hudson.model.Queue;
 import org.junit.After;
@@ -56,6 +57,7 @@ public class MoveAction_doMoveByNameTest {
             StaplerRequest request = Mockito.mock(StaplerRequest.class);
             StaplerResponse response = Mockito.mock(StaplerResponse.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+            when(request.getParameter(VIEW_NAME_PARAM_NAME)).thenReturn("all");
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(
                     String.valueOf(queue.getItems()[1].task.getDisplayName()));
             moveAction.doMove(request, response);


### PR DESCRIPTION
Submitting a form when clicking the links to change the queue order is expensive and makes changing several queue entries shortly after each other quite hard.

This also no longer sends a redirect but will just send a response status. In the error case the response will be either 400 when the item was not found or a 404 in case of an illegal value for the movetype parameter

Testing:
Manually tested that clicking the buttons still works as expected
Executed curl commands that succeed or fail with a 404 or 400 and verified that the response is as expected with json in the body in case of an error

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed