### PR TITLE
Made /i available for java style and removed itemIdMode for itemId, introduced new api with itemIdMode

### DIFF
--- a/docs_src/docs/CLI.md
+++ b/docs_src/docs/CLI.md
@@ -66,7 +66,7 @@ you can Copy Link of a button and edit the URL).
 
 The `itemId` processing logic is as follows:
 
-* if the additional `&itemIdMode=regex` query parameter is set, the `itemId` is interpreted as a Groovy/PERL style
+* If no ID, nor exact match is matching, the `itemId` is interpreted as a Groovy/PERL style
   regular expression (if it follows tilde-slash markup like `~/.../`), or as a Java style regular expression.
   This mode is discussed in more detail in the [Regular expressions](#regular-expressions) section below.
 * otherwise if the `itemId` is a number, it is interpreted as a queue item number,
@@ -147,8 +147,7 @@ http://${JENKINS_URL}/simpleQueueResetUnsafe/reset
 
 #### Regular expressions
 The `itemId` parameter can also accept a regular expression to select several queue items at once (such as different
-parts of the same running job). This mode requires that the additional `&itemIdMode=regex` query parameter is set.
-In this case the `itemId` parameter is not checked as a queue item number nor as an exact job name match.
+parts of the same running job).
 
 Two regular expression markup modes are currently supported, as detailed below. Keep in mind that either way the
 expression is handled by java `Pattern` and `Matcher` classes, so you can use any of the regular expression syntax

--- a/docs_src/docs/CLI.md
+++ b/docs_src/docs/CLI.md
@@ -153,6 +153,10 @@ Two regular expression markup modes are currently supported, as detailed below. 
 expression is handled by java `Pattern` and `Matcher` classes, so you can use any of the regular expression syntax
 supported by those classes.
 
+both regular expressions can append `/switches`. Eg `/i` will switch to case insensitive. Next to that, there are also dDn,
+which determines where to search d - display name - default; D - full display name and n - name.
+So `.*job/idnD` will search case-insensitive for any "job" suffixes display name, full display name and in name.
+
 NOTE: The examples below are illustrative and may require URL-escaping in an actual HTTP query.
 
 ##### Groovy/PERL style expressions

--- a/docs_src/docs/CLI.md
+++ b/docs_src/docs/CLI.md
@@ -46,6 +46,7 @@ the [Complex names](#complex-names) section below.
      * escaping
      * full names
    * [HTTP return value](#http-return-value)
+ * [strict api](#strict-api)
 
 ### overview
 The `viewName` is optional and is obvious.
@@ -66,12 +67,10 @@ you can Copy Link of a button and edit the URL).
 
 The `itemId` processing logic is as follows:
 
-* If no ID, nor exact match is matching, the `itemId` is interpreted as a Groovy/PERL style
-  regular expression (if it follows tilde-slash markup like `~/.../`), or as a Java style regular expression.
-  This mode is discussed in more detail in the [Regular expressions](#regular-expressions) section below.
-* otherwise if the `itemId` is a number, it is interpreted as a queue item number,
+* if the `itemId` is a number, it is interpreted as a queue item number,
 * otherwise the `itemId` string is interpreted as an exact name of a queue item (possibly needs URL-escaping in
   the HTTP query).
+* If no ID is found (or the input is not an number), an exact match is attempted. If again nothing is found, the `itemId` is interpreted as a Java style regular expression. A Groovy/PERL style regular expression is also possible, if it follows tilde-slash markup like `~/.../`. Which literally just preffix+suffix the expression by `.*`. This mode is discussed in more detail in the [Regular expressions](#regular-expressions) section below.
 
 If no job is found, the plugin will simply fall through without sorting the queue.
 
@@ -153,7 +152,7 @@ Two regular expression markup modes are currently supported, as detailed below. 
 expression is handled by java `Pattern` and `Matcher` classes, so you can use any of the regular expression syntax
 supported by those classes.
 
-both regular expressions can append `/switches`. Eg `/i` will switch to case insensitive. Next to that, there are also dDn,
+Both types of regular expressions can append `/switches`. Eg `/i` will switch to case insensitive. Next to that, there are also dDn,
 which determines where to search d - display name - default; D - full display name and n - name.
 So `.*job/idnD` will search case-insensitive for any "job" suffixes display name, full display name and in name.
 
@@ -218,3 +217,24 @@ The error responses contain a json body with more details, e.g.:
   "message": "Queue item '1234' not found"
 }
 ```
+Many responses contains also reason of finding nothing.
+
+## strict api
+Because of the waterfall: number->match->regex(es), in addition with switches, and concerns about `display` to match against, an new strict api was introduced:
+
+* `moveType` remains mandatory parameter to determine movement
+* `viewName` remains optional parameter to specify view
+* use `itemIdExt` instead of `itemId`. Those two are mutually exclusive. `itemId` value is resolved as old versatile api, but `itemIdExt` is resolving via new apu
+* `itemMode` is mandatory argument for new api. Must be set exactly onece, by one of following (case insensitive) values:
+  * `QID` - item id exact item selection for internal jenkins operations
+  * `EXACT` - to match by exact match
+  * `REGEX` - as java-like regex, withou `/args`
+  * `GREGEX` - as groovy like regex withou `~//args` (so basically regex with prepend/append of `.*`.)
+* `itemTarget` to specify where/how match against. Can be set multipletimes, but at least once. Each value can be one of the (case insensitive) following:
+  * `DISPLAY` - search in display name
+  * `FULLDISPLAY` - search in full display name
+  * `NAME` - search in item name
+  * `I` - search is case insensitive
+  * Unlike original old `itemId` mode, item target is used also in `exact` match mode, and not only in regex mode.
+
+Strict api is currently not used, is considered as experimental, but  shoudl resolve any issue the versatile api may failedue to its number->match->regex(es) waterfall nature.

--- a/src/main/java/cz/mendelu/xotradov/ItemMode.java
+++ b/src/main/java/cz/mendelu/xotradov/ItemMode.java
@@ -1,0 +1,8 @@
+package cz.mendelu.xotradov;
+
+/**
+ * Lists supported types of moves.
+ */
+public enum ItemMode {
+    QID, EXACT, REGEX, GREGEX
+}

--- a/src/main/java/cz/mendelu/xotradov/ItemTarget.java
+++ b/src/main/java/cz/mendelu/xotradov/ItemTarget.java
@@ -1,0 +1,8 @@
+package cz.mendelu.xotradov;
+
+/**
+ * Lists supported types of moves.
+ */
+public enum ItemTarget {
+    DISPLAY, FULLDISPLAY, NAME, I
+}

--- a/src/main/java/cz/mendelu/xotradov/MoveAction.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveAction.java
@@ -4,9 +4,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.*;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -45,10 +44,10 @@ public class MoveAction extends MoveActionWorker implements RootAction  {
      * @param response Stapler response send back to users browser
      */
     @RequirePOST
-    public void doMove(final StaplerRequest request, final StaplerResponse response) {
+    public void doMove(final StaplerRequest2 request, final StaplerResponse2 response) {
         Jenkins j = Jenkins.get();
         if (!j.hasPermission(PermissionHandler.SIMPLE_QUEUE_MOVE_PERMISSION)) {
-            response.setStatus(StaplerResponse.SC_FORBIDDEN);
+            response.setStatus(StaplerResponse2.SC_FORBIDDEN);
             return;
         }
         try {
@@ -58,7 +57,7 @@ public class MoveAction extends MoveActionWorker implements RootAction  {
             }
         } catch (Exception e) {
             logger.warning(e.toString());
-            response.setStatus(StaplerResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(StaplerResponse2.SC_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -71,7 +71,7 @@ public class MoveActionWorker {
                         setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse.SC_BAD_REQUEST);
                         return;
                     }
-                    items = findItemsByPattern(queue, pattern);
+                    items = findItemsByPattern(queue, pattern, rp);
                 }
             }
             if (items == null || items.length == 0) {
@@ -123,19 +123,36 @@ public class MoveActionWorker {
      * @param idParamPattern The pattern to match against task display names.
      * @return An array of matching Queue.Item objects, or null if no matches are found.
      */
-    protected Queue.Item[] findItemsByPattern(Queue queue, Pattern idParamPattern) {
+    protected Queue.Item[] findItemsByPattern(Queue queue, Pattern idParamPattern, RegexWithParams rp) {
         List<Queue.Item> items = new ArrayList<>();
         for (Queue.Item item : queue.getItems()) {
             if (item.isBuildable()) {
                 if (item.task != null) {
-                    Matcher matcher = idParamPattern.matcher(item.task.getDisplayName());
-                    if (matcher.matches()) items.add(item);
+                    boolean matched = false;
+                    if (rp.isDisplayName()) {
+                        matched = isMatched(idParamPattern, item.task.getDisplayName(), items, item);
+                    }
+                    if (!matched && rp.isFullDisplayName()) {
+                        matched = isMatched(idParamPattern, item.task.getFullDisplayName(), items, item);
+                    }
+                    if (!matched && rp.isName()) {
+                        isMatched(idParamPattern, item.task.getName(), items, item);
+                    }
                 }
             }
         }
         if (items.isEmpty())
             return null;
         return items.toArray(new Queue.Item[0]);
+    }
+
+    private static boolean isMatched(Pattern pattern, String taskpart, List<Queue.Item> items, Queue.Item item) {
+        Matcher matcher = pattern.matcher(taskpart);
+        if (matcher.matches()) {
+            items.add(item);
+            return true;
+        }
+        return false;
     }
 
     protected void move(@NonNull Queue queue, @NonNull Queue.Item item, @NonNull MoveType moveType, View view) {

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -30,63 +30,52 @@ public class MoveActionWorker {
     protected static final Logger logger = Logger.getLogger(MoveActionWorker.class.getName());
     public static final String MOVE_TYPE_PARAM_NAME = "moveType";
     public static final String ITEM_ID_PARAM_NAME = "itemId";
-    public static final String ITEM_ID_PARAM_MODE = "itemIdMode";
+    //public static final String ITEM_ID_PARAM_MODE = "itemIdMode"; this switch is currently not used, and will part of new ITEM_ID_PARAM_NAME2 api
     public static final String VIEW_NAME_PARAM_NAME = "viewName";
     protected boolean isSorterSet = false;
 
     protected void moveImpl(StaplerRequest request, StaplerResponse response, Queue queue, Jenkins j) throws IOException {
         try {
-            String idParam = request.getParameter(ITEM_ID_PARAM_NAME);
-            String idParamMode = request.getParameter(ITEM_ID_PARAM_MODE);
+            final String idParam = request.getParameter(ITEM_ID_PARAM_NAME);
             Queue.Item[] items = null;
-
-            if (idParamMode != null && idParamMode.equals("regex")) {
-                boolean caseInsensitive = idParam.endsWith("/i");
-                if (idParam.startsWith("~/") && (idParam.endsWith("/") || caseInsensitive)) {
-                    /* "Groovy/PERL style" */
-                    char[] tmp = new char[idParam.length()];
-                    idParam.getChars(2, idParam.length() - (caseInsensitive ? 2 : 1), tmp, 0);
-                    String regexStr = String.valueOf(tmp).trim();
-                    items = findItemsByPattern(queue,
-                            Pattern.compile(regexStr, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0),
-                            true
-                    );
-                } else {
-                    /* "Java style"
-                     * Assume the whole idParam string makes sense as a java-style regex
-                     * (meaning it Matcher::matches() the whole item.task.getDisplayName()
-                     * string), and the value must be surrounded by `.*` to match from
-                     * start and/or to the end of string respectively (like find() above
-                     * does by default) */
-                    items = findItemsByPattern(queue,
-                            Pattern.compile(idParam),
-                            false
-                    );
+            try {
+                // This handles queue item numbers; to search
+                // by the number of a build etc. use the regex mode!
+                Queue.Item item = queue.getItem(Long.parseLong(idParam));
+                if (item != null) {
+                    items = new Queue.Item[1];
+                    items[0] = item;
                 }
-            } else {
-                // Non-regex mode
-                try {
-                    Queue.Item item = queue.getItem(Long.parseLong(idParam));
-                    if (item != null) {
-                        items = new Queue.Item[1];
-                        items[0] = item;
-                    } // This handles queue item numbers; to search
-                      // by the number of a build etc. use the regex mode!
-                } catch (NumberFormatException nfe) {
-                    Queue.Item item = findItemByName(queue, idParam);
-                    if (item != null) {
-                        items = new Queue.Item[1];
-                        items[0] = item;
+            } catch (NumberFormatException nfe) {
+                //this handles search by name
+                Queue.Item item = findItemByName(queue, idParam);
+                if (item != null) {
+                    items = new Queue.Item[1];
+                    items[0] = item;
+                } else {
+                    // regex mode
+                    RegexWithParams rp;
+                    if (RegexWithParams.isGroovy(idParam)) {
+                        rp = RegexWithParams.groovyLikeRegexWithParams(idParam);
+                        if (rp.regex.equals(".*.*")) {
+                            setResponseToError("Empty grovy-like regex  " + rp.regex + "/" + idParam, response, StaplerResponse.SC_BAD_REQUEST);
+                            return;
+                        }
+                    } else {
+                        rp = RegexWithParams.javaLikeRegexWithParams(idParam);
                     }
+                    Pattern pattern;
+                    try {
+                        pattern = rp.getPattern();
+                    } catch (Exception ex) {
+                        setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse.SC_BAD_REQUEST);
+                        return;
+                    }
+                    items = findItemsByPattern(queue, pattern);
                 }
             }
             if (items == null || items.length == 0) {
-                logger.info("Queue item with id '" + idParam + "' not found");
-                response.setStatus(StaplerResponse.SC_NOT_FOUND);
-                PrintWriter writer = response.getWriter();
-                JSONObject message = new JSONObject();
-                message.put("error", "Queue item with id '" + idParam + "' not found");
-                writer.println(message.toString(2));
+                setResponseToError("Queue item with id '" + idParam + "' not found", response, StaplerResponse.SC_NOT_FOUND);
                 return;
             }
 
@@ -94,12 +83,7 @@ public class MoveActionWorker {
             try {
                 moveType = MoveType.valueOf(request.getParameter(MOVE_TYPE_PARAM_NAME));
             } catch (IllegalArgumentException iae) {
-                logger.info("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME));
-                response.setStatus(StaplerResponse.SC_BAD_REQUEST);
-                PrintWriter writer = response.getWriter();
-                JSONObject message = new JSONObject();
-                message.put("error", "Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME));
-                writer.println(message.toString(2));
+                setResponseToError("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME), response, StaplerResponse.SC_BAD_REQUEST);
                 return;
             }
 
@@ -108,10 +92,18 @@ public class MoveActionWorker {
             Queue.getInstance().maintain();
             response.setStatus(StaplerResponse.SC_OK);
         } catch (Exception ex) {
-            logger.info("unable to simple-queue item " + request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(
-                    Collectors.joining(","))).collect(Collectors.joining("; ")));
+            logger.info("unable to simple-queue item " + request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(Collectors.joining(","))).collect(Collectors.joining("; ")));
             throw ex;
         }
+    }
+
+    private static void setResponseToError(String info, StaplerResponse response, int status) throws IOException {
+        logger.info(info);
+        response.setStatus(status);
+        PrintWriter writer = response.getWriter();
+        JSONObject message = new JSONObject();
+        message.put("error", info);
+        writer.println(message.toString(2));
     }
 
     protected Queue.Item findItemByName(Queue queue, String idParam) {
@@ -129,22 +121,15 @@ public class MoveActionWorker {
      * Finds items in the queue that match the given pattern.
      * @param queue The queue to search in.
      * @param idParamPattern The pattern to match against task display names.
-     * @param useMatcherFind Whether to use Matcher.find() instead of Matcher.matches().
      * @return An array of matching Queue.Item objects, or null if no matches are found.
      */
-    protected Queue.Item[] findItemsByPattern(Queue queue, Pattern idParamPattern, boolean useMatcherFind) {
+    protected Queue.Item[] findItemsByPattern(Queue queue, Pattern idParamPattern) {
         List<Queue.Item> items = new ArrayList<>();
         for (Queue.Item item : queue.getItems()) {
             if (item.isBuildable()) {
                 if (item.task != null) {
                     Matcher matcher = idParamPattern.matcher(item.task.getDisplayName());
-                    if (useMatcherFind) {
-                        if (matcher.find())
-                            items.add(item);
-                    } else {
-                        if (matcher.matches())
-                            items.add(item);
-                    }
+                    if (matcher.matches()) items.add(item);
                 }
             }
         }

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -5,8 +5,8 @@ import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -28,13 +28,19 @@ import net.sf.json.JSONObject;
 
 public class MoveActionWorker {
     protected static final Logger logger = Logger.getLogger(MoveActionWorker.class.getName());
+    //shared
     public static final String MOVE_TYPE_PARAM_NAME = "moveType";
-    public static final String ITEM_ID_PARAM_NAME = "itemId";
-    //public static final String ITEM_ID_PARAM_MODE = "itemIdMode"; this switch is currently not used, and will part of new ITEM_ID_PARAM_NAME2 api
     public static final String VIEW_NAME_PARAM_NAME = "viewName";
+    //versatile
+    public static final String ITEM_ID_PARAM_NAME = "itemId";
+    //strict
+    public static final String ITEM_ID_EXT_PARAM_NAME = "itemIdExt";
+    public static final String ITEM_ID_EXT_PARAM_MODE = "itemMode";  //how: id,exact, regex,g regex
+    public static final String ITEM_ID_EXT_PARAM_TARGET = "itemTarget"; //in: d(isplayName),(full)D(isplayName),(job)n(anme)
+
     protected boolean isSorterSet = false;
 
-    protected void moveImpl(StaplerRequest request, StaplerResponse response, Queue queue, Jenkins j) throws IOException {
+    protected void moveImpl(StaplerRequest2 request, StaplerResponse2 response, Queue queue, Jenkins j) throws IOException {
         try {
             final String idParam = request.getParameter(ITEM_ID_PARAM_NAME);
             Queue.Item[] items = null;
@@ -58,7 +64,7 @@ public class MoveActionWorker {
                     if (RegexWithParams.isGroovy(idParam)) {
                         rp = RegexWithParams.groovyLikeRegexWithParams(idParam);
                         if (rp.regex.equals(".*.*")) {
-                            setResponseToError("Empty grovy-like regex  " + rp.regex + "/" + idParam, response, StaplerResponse.SC_BAD_REQUEST);
+                            setResponseToError("Empty grovy-like regex  " + rp.regex + "/" + idParam, response, StaplerResponse2.SC_BAD_REQUEST);
                             return;
                         }
                     } else {
@@ -68,14 +74,14 @@ public class MoveActionWorker {
                     try {
                         pattern = rp.getPattern();
                     } catch (Exception ex) {
-                        setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse.SC_BAD_REQUEST);
+                        setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse2.SC_BAD_REQUEST);
                         return;
                     }
                     items = findItemsByPattern(queue, pattern, rp);
                 }
             }
             if (items == null || items.length == 0) {
-                setResponseToError("Queue item with id '" + idParam + "' not found", response, StaplerResponse.SC_NOT_FOUND);
+                setResponseToError("Queue item with id '" + idParam + "' not found", response, StaplerResponse2.SC_NOT_FOUND);
                 return;
             }
 
@@ -83,21 +89,21 @@ public class MoveActionWorker {
             try {
                 moveType = MoveType.valueOf(request.getParameter(MOVE_TYPE_PARAM_NAME));
             } catch (IllegalArgumentException iae) {
-                setResponseToError("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME), response, StaplerResponse.SC_BAD_REQUEST);
+                setResponseToError("Wrong move type " + request.getParameter(MOVE_TYPE_PARAM_NAME), response, StaplerResponse2.SC_BAD_REQUEST);
                 return;
             }
 
             View view = j.getView(request.getParameter(VIEW_NAME_PARAM_NAME));
             move(queue, items, moveType, view);
             Queue.getInstance().maintain();
-            response.setStatus(StaplerResponse.SC_OK);
+            response.setStatus(StaplerResponse2.SC_OK);
         } catch (Exception ex) {
             logger.info("unable to simple-queue item " + request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(Collectors.joining(","))).collect(Collectors.joining("; ")));
             throw ex;
         }
     }
 
-    private static void setResponseToError(String info, StaplerResponse response, int status) throws IOException {
+    private static void setResponseToError(String info, StaplerResponse2 response, int status) throws IOException {
         logger.info(info);
         response.setStatus(status);
         PrintWriter writer = response.getWriter();

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -35,53 +35,32 @@ public class MoveActionWorker {
     public static final String ITEM_ID_PARAM_NAME = "itemId";
     //strict
     public static final String ITEM_ID_EXT_PARAM_NAME = "itemIdExt";
-    public static final String ITEM_ID_EXT_PARAM_MODE = "itemMode";  //how: id,exact, regex,g regex
-    public static final String ITEM_ID_EXT_PARAM_TARGET = "itemTarget"; //in: d(isplayName),(full)D(isplayName),(job)n(anme)
+    public static final String ITEM_ID_EXT_PARAM_MODE = "itemMode";  //how: id,exact, regex, gregex (regex with .*  pref and suffix
+    public static final String ITEM_ID_EXT_PARAM_TARGET = "itemTarget"; //in: d(isplayName),(full)D(isplayName),(job)n(ame),(case)I(insensitive) - is expeced multiple times
 
     protected boolean isSorterSet = false;
 
     protected void moveImpl(StaplerRequest2 request, StaplerResponse2 response, Queue queue, Jenkins j) throws IOException {
         try {
+            final String idExtParam = request.getParameter(ITEM_ID_EXT_PARAM_NAME);
             final String idParam = request.getParameter(ITEM_ID_PARAM_NAME);
-            Queue.Item[] items = null;
-            try {
-                // This handles queue item numbers; to search
-                // by the number of a build etc. use the regex mode!
-                Queue.Item item = queue.getItem(Long.parseLong(idParam));
-                if (item != null) {
-                    items = new Queue.Item[1];
-                    items[0] = item;
-                }
-            } catch (NumberFormatException nfe) {
-                //this handles search by name
-                Queue.Item item = findItemByName(queue, idParam);
-                if (item != null) {
-                    items = new Queue.Item[1];
-                    items[0] = item;
-                } else {
-                    // regex mode
-                    RegexWithParams rp;
-                    if (RegexWithParams.isGroovy(idParam)) {
-                        rp = RegexWithParams.groovyLikeRegexWithParams(idParam);
-                        if (rp.regex.equals(".*.*")) {
-                            setResponseToError("Empty grovy-like regex  " + rp.regex + "/" + idParam, response, StaplerResponse2.SC_BAD_REQUEST);
-                            return;
-                        }
-                    } else {
-                        rp = RegexWithParams.javaLikeRegexWithParams(idParam);
-                    }
-                    Pattern pattern;
-                    try {
-                        pattern = rp.getPattern();
-                    } catch (Exception ex) {
-                        setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse2.SC_BAD_REQUEST);
-                        return;
-                    }
-                    items = findItemsByPattern(queue, pattern, rp);
-                }
+            String id = "unknown";
+            if (idExtParam != null && idParam != null) {
+                setResponseToError(ITEM_ID_PARAM_NAME + " and " + ITEM_ID_EXT_PARAM_NAME + " are mutually exclusive", response, StaplerResponse2.SC_BAD_REQUEST);
+                return;
             }
+            Queue.Item[] items = null;
+            if (idParam != null) {
+                id = idParam;
+                items = getItemsByVersatileApi(response, queue, idParam);
+            }
+            if (idExtParam != null) {
+                id = idExtParam;
+                items = getItemsByStrictApi(response, request, queue, idExtParam);
+            }
+
             if (items == null || items.length == 0) {
-                setResponseToError("Queue item with id '" + idParam + "' not found", response, StaplerResponse2.SC_NOT_FOUND);
+                setResponseToError("Queue item with id '" + id + "' not found", response, StaplerResponse2.SC_NOT_FOUND);
                 return;
             }
 
@@ -98,9 +77,82 @@ public class MoveActionWorker {
             Queue.getInstance().maintain();
             response.setStatus(StaplerResponse2.SC_OK);
         } catch (Exception ex) {
-            logger.info("unable to simple-queue item " + request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(Collectors.joining(","))).collect(Collectors.joining("; ")));
-            throw ex;
+            setResponseToError("unable to simple-queue item " +
+                    request.getParameterMap().entrySet().stream().map(a -> a.getKey() + ": " + Arrays.stream(a.getValue()).collect(Collectors.joining(","))).collect(Collectors.joining("; ")) +
+                    " ;" + ex.getMessage(),
+                    response, StaplerResponse2.SC_BAD_REQUEST);
         }
+    }
+
+    private Queue.Item[] getItemsByStrictApi(StaplerResponse2 response, StaplerRequest2 request, Queue queue, String idExtParam) throws IOException {
+        //not yet implemented
+        final String mode = request.getParameter(ITEM_ID_EXT_PARAM_MODE);
+        final String[] target = request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET);
+        if (mode == null || target == null) {
+            setResponseToError("One  " + ITEM_ID_EXT_PARAM_MODE + " and at least one " + ITEM_ID_EXT_PARAM_TARGET + " is mandatory in strict mode ", response, StaplerResponse2.SC_BAD_REQUEST);
+            return null;
+        }
+        ItemMode itemMode;
+        try {
+            itemMode = ItemMode.valueOf(mode);
+        } catch (IllegalArgumentException iae) {
+            setResponseToError("invalid mode  " + mode + " expected: " + Arrays.toString(ItemMode.values()), response, StaplerResponse2.SC_BAD_REQUEST);
+            return null;
+        }
+        List<ItemTarget> itemTargets = new ArrayList<>();
+        for(String targetItem : target) {
+            try{
+            itemTargets.add(ItemTarget.valueOf(targetItem));
+            } catch (IllegalArgumentException iae) {
+                setResponseToError("invalid target  " + targetItem + " expected: " + Arrays.toString(ItemTarget.values()), response, StaplerResponse2.SC_BAD_REQUEST);
+                return null;
+            }
+        }
+        System.out.println(itemMode);
+        System.out.println(Arrays.toString(target));
+        System.out.println(itemTargets.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        return null;
+    }
+
+    private Queue.Item[] getItemsByVersatileApi(StaplerResponse2 response, Queue queue, String idParam) throws IOException {
+        Queue.Item[] items = null;
+        try {
+            // This handles queue item numbers; to search
+            // by the number of a build etc. use the regex mode!
+            Queue.Item item = queue.getItem(Long.parseLong(idParam));
+            if (item != null) {
+                items = new Queue.Item[1];
+                items[0] = item;
+            }
+        } catch (NumberFormatException nfe) {
+            //this handles search by name
+            Queue.Item item = findItemByName(queue, idParam);
+            if (item != null) {
+                items = new Queue.Item[1];
+                items[0] = item;
+            } else {
+                // regex mode
+                RegexWithParams rp;
+                if (RegexWithParams.isGroovy(idParam)) {
+                    rp = RegexWithParams.groovyLikeRegexWithParams(idParam);
+                    if (rp.regex.equals(".*.*")) {
+                        setResponseToError("Empty grovy-like regex  " + rp.regex + "/" + idParam, response, StaplerResponse2.SC_BAD_REQUEST);
+                        return null;
+                    }
+                } else {
+                    rp = RegexWithParams.javaLikeRegexWithParams(idParam);
+                }
+                Pattern pattern;
+                try {
+                    pattern = rp.getPattern();
+                } catch (Exception ex) {
+                    setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse2.SC_BAD_REQUEST);
+                    return null;
+                }
+                items = findItemsByPattern(queue, pattern, rp);
+            }
+        }
+        return items;
     }
 
     private static void setResponseToError(String info, StaplerResponse2 response, int status) throws IOException {

--- a/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
+++ b/src/main/java/cz/mendelu/xotradov/MoveActionWorker.java
@@ -5,6 +5,8 @@ import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import org.jspecify.annotations.Nullable;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 
@@ -85,16 +87,19 @@ public class MoveActionWorker {
     }
 
     private Queue.Item[] getItemsByStrictApi(StaplerResponse2 response, StaplerRequest2 request, Queue queue, String idExtParam) throws IOException {
-        //not yet implemented
         final String mode = request.getParameter(ITEM_ID_EXT_PARAM_MODE);
         final String[] target = request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET);
         if (mode == null || target == null) {
             setResponseToError("One  " + ITEM_ID_EXT_PARAM_MODE + " and at least one " + ITEM_ID_EXT_PARAM_TARGET + " is mandatory in strict mode ", response, StaplerResponse2.SC_BAD_REQUEST);
             return null;
         }
+        if (idExtParam == null || idExtParam.isBlank()) {
+            setResponseToError(ITEM_ID_EXT_PARAM_NAME + " can not be empty", response, StaplerResponse2.SC_BAD_REQUEST);
+            return null;
+        }
         ItemMode itemMode;
         try {
-            itemMode = ItemMode.valueOf(mode);
+            itemMode = ItemMode.valueOf(mode.toUpperCase());
         } catch (IllegalArgumentException iae) {
             setResponseToError("invalid mode  " + mode + " expected: " + Arrays.toString(ItemMode.values()), response, StaplerResponse2.SC_BAD_REQUEST);
             return null;
@@ -102,16 +107,53 @@ public class MoveActionWorker {
         List<ItemTarget> itemTargets = new ArrayList<>();
         for(String targetItem : target) {
             try{
-            itemTargets.add(ItemTarget.valueOf(targetItem));
+                itemTargets.add(ItemTarget.valueOf(targetItem.toUpperCase()));
             } catch (IllegalArgumentException iae) {
                 setResponseToError("invalid target  " + targetItem + " expected: " + Arrays.toString(ItemTarget.values()), response, StaplerResponse2.SC_BAD_REQUEST);
                 return null;
             }
         }
-        System.out.println(itemMode);
-        System.out.println(Arrays.toString(target));
-        System.out.println(itemTargets.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        switch (itemMode) {
+            case QID ->  {
+                Queue.Item item = queue.getItem(Long.parseLong(idExtParam));
+                return toSingleItemArray(item);
+            }
+            case EXACT ->   {
+                Queue.Item item = findItemByName(queue, idExtParam, RegexWithParams.exact("", itemTargets));
+                return toSingleItemArray(item);
+            }
+            case REGEX ->   {
+                Pattern pattern;
+                RegexWithParams rp = RegexWithParams.exact(idExtParam.trim(), itemTargets);
+                try {
+                    pattern = rp.getPattern();
+                } catch (Exception ex) {
+                    setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse2.SC_BAD_REQUEST);
+                    return null;
+                }
+                return findItemsByPattern(queue, pattern, rp);
+            }
+            case GREGEX ->  {
+                Pattern pattern;
+                RegexWithParams rp = RegexWithParams.exact(".*"+idExtParam.trim()+".*", itemTargets);
+                try {
+                    pattern = rp.getPattern();
+                } catch (Exception ex) {
+                    setResponseToError("Can not compile  " + rp.regex + ": " + ex.getMessage(), response, StaplerResponse2.SC_BAD_REQUEST);
+                    return null;
+                }
+                return findItemsByPattern(queue, pattern, rp);
+            }
+        }
         return null;
+    }
+
+    private static Queue.Item @Nullable [] toSingleItemArray(Queue.Item item) {
+        if (item != null) {
+            return new Queue.Item[]{item};
+        } else {
+            return null;
+        }
     }
 
     private Queue.Item[] getItemsByVersatileApi(StaplerResponse2 response, Queue queue, String idParam) throws IOException {
@@ -126,7 +168,7 @@ public class MoveActionWorker {
             }
         } catch (NumberFormatException nfe) {
             //this handles search by name
-            Queue.Item item = findItemByName(queue, idParam);
+            Queue.Item item = findItemByName(queue, idParam, null);
             if (item != null) {
                 items = new Queue.Item[1];
                 items[0] = item;
@@ -161,14 +203,56 @@ public class MoveActionWorker {
         PrintWriter writer = response.getWriter();
         JSONObject message = new JSONObject();
         message.put("error", info);
-        writer.println(message.toString(2));
+        if (writer != null) { //mocked writer was returning null, killing tests
+            writer.println(message.toString(2));
+        }
     }
 
-    protected Queue.Item findItemByName(Queue queue, String idParam) {
-        for (Queue.Item item : queue.getItems()) {
-            if (item.isBuildable()) {
-                if (item.task != null && item.task.getDisplayName().equals(idParam)) {
-                    return item;
+    protected Queue.Item findItemByName(Queue queue, String idParam, RegexWithParams params) {
+        if (params == null) {
+            for (Queue.Item item : queue.getItems()) {
+                if (item.isBuildable()) {
+                    if (item.task != null && item.task.getDisplayName().equals(idParam)) {
+                        return item;
+                    }
+                }
+            }
+        } else {
+            for (Queue.Item item : queue.getItems()) {
+                if (item.isBuildable() && item.task != null) {
+                    if (params.isDisplayName()) {
+                        if (params.isCaseInsensitive()) {
+                            if (item.task.getDisplayName().equalsIgnoreCase(idParam)) {
+                                return item;
+                            }
+                        } else {
+                            if (item.task.getDisplayName().equals(idParam)) {
+                                return item;
+                            }
+                        }
+                    }
+                    if (params.isFullDisplayName()) {
+                        if (params.isCaseInsensitive()) {
+                            if (item.task.getFullDisplayName().equalsIgnoreCase(idParam)) {
+                                return item;
+                            }
+                        } else {
+                            if (item.task.getFullDisplayName().equals(idParam)) {
+                                return item;
+                            }
+                        }
+                    }
+                    if (params.isName()) {
+                        if (params.isCaseInsensitive()) {
+                            if (item.task.getName().equalsIgnoreCase(idParam)) {
+                                return item;
+                            }
+                        } else {
+                            if (item.task.getName().equals(idParam)) {
+                                return item;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
+++ b/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
@@ -52,4 +52,20 @@ public class RegexWithParams {
         boolean caseInsensitive = params.contains("i");
         return Pattern.compile(regex, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
     }
+
+    public boolean isDisplayName() {
+        if (params.contains("d")) {
+            return true;
+        }
+        return !isFullDisplayName() && !isName();
+    }
+
+    public boolean isFullDisplayName() {
+        return params.contains("D");
+    }
+
+    public boolean isName() {
+        return params.contains("n");
+    }
+
 }

--- a/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
+++ b/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
@@ -1,5 +1,6 @@
 package cz.mendelu.xotradov;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class RegexWithParams {
@@ -48,9 +49,33 @@ public class RegexWithParams {
         return (idParam.matches("~/.*/.*"));
     }
 
+    public static RegexWithParams exact(String regex, List<ItemTarget> itemTargets) {
+        StringBuilder sb = new StringBuilder();
+        for (ItemTarget itemTarget : itemTargets) {
+            switch (itemTarget) {
+                case DISPLAY -> {
+                    sb.append("d");
+                }
+                case FULLDISPLAY -> {
+                    sb.append("D");
+                }
+                case NAME -> {
+                    sb.append("n");
+                }
+                case I -> {
+                    sb.append("i");
+                }
+            }
+        }
+        return new RegexWithParams(regex, sb.toString());
+    }
+
     public Pattern getPattern() {
-        boolean caseInsensitive = params.contains("i");
-        return Pattern.compile(regex, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+        return Pattern.compile(regex, isCaseInsensitive() ? Pattern.CASE_INSENSITIVE : 0);
+    }
+
+    public boolean isCaseInsensitive() {
+        return params.contains("i");
     }
 
     public boolean isDisplayName() {

--- a/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
+++ b/src/main/java/cz/mendelu/xotradov/RegexWithParams.java
@@ -1,0 +1,55 @@
+package cz.mendelu.xotradov;
+
+import java.util.regex.Pattern;
+
+public class RegexWithParams {
+
+    final String regex;
+    final String params;
+
+    public RegexWithParams(String regex, String params) {
+        this.regex = regex;
+        this.params = params;
+    }
+
+    /* "Groovy/PERL style" declaration
+     * This ne is always all-matching like matcher.find
+     * The /params eg /i is recgnized
+     */
+    public static RegexWithParams groovyLikeRegexWithParams(String futureRegex) {
+        String params = "";
+        int lastSlash = futureRegex.lastIndexOf("/");
+        params = futureRegex.substring(lastSlash + 1);
+        futureRegex = futureRegex.substring(0, lastSlash).replaceFirst("~/", "");
+        futureRegex = futureRegex.trim();
+        futureRegex = ".*" + futureRegex + ".*";
+        return new RegexWithParams(futureRegex, params);
+    }
+
+    /* "Java style"
+     * Assume the whole idParam string makes sense as a java-style regex
+     * (meaning it Matcher::matches() the whole item.task.getDisplayName()
+     * string), and the value must be surrounded by `.*` to match from
+     * start and/or to the end of string respectively (like find() above
+     * does by default). The /i and other params are understood too.
+     */
+    public static RegexWithParams javaLikeRegexWithParams(String futureRegex) {
+        String params = "";
+        int lastSlash = futureRegex.lastIndexOf("/");
+        if (lastSlash >= 0) {
+            params = futureRegex.substring(lastSlash + 1);
+            futureRegex = futureRegex.substring(0, lastSlash);
+        }
+        futureRegex = futureRegex.trim();
+        return new RegexWithParams(futureRegex, params);
+    }
+
+    public static boolean isGroovy(String idParam) {
+        return (idParam.matches("~/.*/.*"));
+    }
+
+    public Pattern getPattern() {
+        boolean caseInsensitive = params.contains("i");
+        return Pattern.compile(regex, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+    }
+}

--- a/src/main/java/cz/mendelu/xotradov/ResetAction.java
+++ b/src/main/java/cz/mendelu/xotradov/ResetAction.java
@@ -4,8 +4,8 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.model.RootAction;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.util.logging.Logger;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -16,7 +16,7 @@ public class ResetAction implements RootAction {
     private static Logger logger = Logger.getLogger(ResetAction.class.getName());
 
     @RequirePOST
-    public void doReset(final StaplerRequest request, final StaplerResponse response) {
+    public void doReset(final StaplerRequest2 request, final StaplerResponse2 response) {
         if (!Jenkins.get().hasPermission(PermissionHandler.SIMPLE_QUEUE_RESET_PERMISSION)) return;
         UnsafeResetAction.resetImpl(request, response);
     }

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueConfig.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueConfig.java
@@ -4,7 +4,7 @@ package cz.mendelu.xotradov;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import hudson.Extension;
 
@@ -38,7 +38,7 @@ public class SimpleQueueConfig extends GlobalConfiguration {
 
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
         req.bindJSON(this, json);
         save();
         return super.configure(req, json);

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
@@ -63,6 +63,12 @@ public class SimpleQueueWidget extends Widget {
     public static String getItemIdName() { return MoveAction.ITEM_ID_PARAM_NAME;}
     @SuppressWarnings("unused") // jelly
     public static String getViewNameParamName() { return MoveAction.VIEW_NAME_PARAM_NAME;}
+    @SuppressWarnings("unused") // jelly
+    public static String getItemIdExtName() { return MoveAction.ITEM_ID_EXT_PARAM_NAME;}
+    @SuppressWarnings("unused") // jelly
+    public static String getItemIdExtParamMode() { return MoveAction.ITEM_ID_EXT_PARAM_MODE;}
+    @SuppressWarnings("unused") // jelly
+    public static String getItemIdExtParamTarget() { return MoveAction.ITEM_ID_EXT_PARAM_TARGET;}
 
     @Extension(ordinal = 100)
     public static final class ViewFactoryImpl extends WidgetFactory<View, SimpleQueueWidget> {

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueWidget.java
@@ -62,8 +62,6 @@ public class SimpleQueueWidget extends Widget {
     @SuppressWarnings("unused") // jelly
     public static String getItemIdName() { return MoveAction.ITEM_ID_PARAM_NAME;}
     @SuppressWarnings("unused") // jelly
-    public static String getItemIdMode() { return MoveAction.ITEM_ID_PARAM_MODE;}
-    @SuppressWarnings("unused") // jelly
     public static String getViewNameParamName() { return MoveAction.VIEW_NAME_PARAM_NAME;}
 
     @Extension(ordinal = 100)

--- a/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeMoveAction.java
@@ -1,8 +1,8 @@
 package cz.mendelu.xotradov;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.util.logging.Logger;
 
@@ -35,7 +35,7 @@ public class UnsafeMoveAction extends MoveActionWorker implements RootAction {
     }
 
 
-    public void doMove(final StaplerRequest request, final StaplerResponse response) {
+    public void doMove(final StaplerRequest2 request, final StaplerResponse2 response) {
         if (!SimpleQueueConfig.getInstance().isEnableUnsafe()) {
             throw new IllegalArgumentException("Unsafe reset api attempted without being enabled");
         }
@@ -46,6 +46,6 @@ public class UnsafeMoveAction extends MoveActionWorker implements RootAction {
                 moveImpl(request, response, queue, j);
             }
         } catch (Exception e) {
-            response.setStatus(StaplerResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(StaplerResponse2.SC_INTERNAL_SERVER_ERROR);
         }    }
 }

--- a/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
+++ b/src/main/java/cz/mendelu/xotradov/UnsafeResetAction.java
@@ -1,7 +1,7 @@
 package cz.mendelu.xotradov;
 
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -18,14 +18,14 @@ public class UnsafeResetAction implements RootAction {
     private static Logger logger = Logger.getLogger(UnsafeResetAction.class.getName());
 
     //curl http://my.url:8080/simpleQueueResetUnsafe/reset
-    public void doReset(final StaplerRequest request, final StaplerResponse response) {
+    public void doReset(final StaplerRequest2 request, final StaplerResponse2 response) {
         if (!SimpleQueueConfig.getInstance().isEnableUnsafe()) {
             throw new IllegalArgumentException("Unsafe reset api attempted without being enabled");
         }
         resetImpl(request, response);
     }
 
-    public static void resetImpl(final StaplerRequest request, final StaplerResponse response) {
+    public static void resetImpl(final StaplerRequest2 request, final StaplerResponse2 response) {
         QueueSorter queueSorter = Jenkins.get().getQueue().getSorter();
         if (queueSorter instanceof SimpleQueueSorter) {
             ((SimpleQueueSorter) queueSorter).reset();

--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/bulk-move-buttons.js
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/bulk-move-buttons.js
@@ -7,8 +7,6 @@ document.querySelectorAll('.BulkMoveRegex_button').forEach(button => {
         parameters['moveType']=button.dataset.var;   // (named via "data-var" in original caller)
         // ex-jelly: '${it.getItemIdName()}'
         parameters['itemId']=findPreviousFormItem(this, 'BulkMoveRegex').value;
-        // ex-jelly: '${it.getItemIdMode()}'
-        parameters['itemIdMode']='regex';
 
         // Tried to use jenkins.baseUrl provided by jenkins.js but it is not global or something?
         fetch(document.head.dataset.rooturl + '/simpleMove/move', {

--- a/src/test/java/cz/mendelu/xotradov/RegexWithParamsTest.java
+++ b/src/test/java/cz/mendelu/xotradov/RegexWithParamsTest.java
@@ -63,4 +63,18 @@ class RegexWithParamsTest {
         assertFalse(RegexWithParams.isGroovy("bl/ah"));
         assertFalse(RegexWithParams.isGroovy("b~/l/ah"));
     }
+
+    @Test
+    void isDisplayNameTest() {
+        assertTrue(RegexWithParams.groovyLikeRegexWithParams("~//i").isDisplayName());
+        assertTrue(RegexWithParams.groovyLikeRegexWithParams("~//").isDisplayName());
+        assertTrue(RegexWithParams.javaLikeRegexWithParams("blah/i").isDisplayName());
+        assertTrue(RegexWithParams.javaLikeRegexWithParams("blah/").isDisplayName());
+        assertTrue(RegexWithParams.javaLikeRegexWithParams("blah").isDisplayName());
+        assertFalse(RegexWithParams.javaLikeRegexWithParams("blah/D").isDisplayName());
+        assertTrue(RegexWithParams.javaLikeRegexWithParams("blah/Dd").isDisplayName());
+        assertFalse(RegexWithParams.javaLikeRegexWithParams("blah/n").isDisplayName());
+        assertFalse(RegexWithParams.javaLikeRegexWithParams("blah/DnN").isDisplayName());
+        assertTrue(RegexWithParams.javaLikeRegexWithParams("blah/DnNd").isDisplayName());
+    }
 }

--- a/src/test/java/cz/mendelu/xotradov/RegexWithParamsTest.java
+++ b/src/test/java/cz/mendelu/xotradov/RegexWithParamsTest.java
@@ -1,0 +1,66 @@
+package cz.mendelu.xotradov;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegexWithParamsTest {
+
+
+    @Test
+    void crateBasicJavaRegex() {
+        RegexWithParams r = RegexWithParams.javaLikeRegexWithParams("a[12]");
+        assertEquals("a[12]", r.regex);
+        assertEquals("", r.params);
+    }
+
+    @Test
+    void crateBasicJavaRegexWithParams() {
+        RegexWithParams r = RegexWithParams.javaLikeRegexWithParams("a[12]/abc");
+        assertEquals("a[12]", r.regex);
+        assertEquals("abc", r.params);
+    }
+
+    @Test
+    void trickJavaSlash() {
+        RegexWithParams r = RegexWithParams.javaLikeRegexWithParams("sla/sh/");
+        assertEquals("sla/sh", r.regex);
+        assertEquals("", r.params);
+    }
+
+
+    @Test
+    void crateBasicGroovyRegex() {
+        RegexWithParams r = RegexWithParams.groovyLikeRegexWithParams("~/a[12]/");
+        assertEquals(".*a[12].*", r.regex);
+        assertEquals("", r.params);
+    }
+
+    @Test
+    void crateBasicGroovyRegexWithParams() {
+        RegexWithParams r = RegexWithParams.groovyLikeRegexWithParams("~/a[12]/abc");
+        assertEquals(".*a[12].*", r.regex);
+        assertEquals("abc", r.params);
+    }
+
+    @Test
+    void trickGroovySlash() {
+        RegexWithParams r = RegexWithParams.groovyLikeRegexWithParams("~/sla/sh/");
+        assertEquals(".*sla/sh.*", r.regex);
+        assertEquals("", r.params);
+    }
+
+    @Test
+    void isGroovyTest() {
+        assertTrue(RegexWithParams.isGroovy("~//"));
+        assertTrue(RegexWithParams.isGroovy("~/blah/"));
+        assertTrue(RegexWithParams.isGroovy("~/bl/ah/"));
+        assertTrue(RegexWithParams.isGroovy("~/bl/ah/params"));
+        assertTrue(RegexWithParams.isGroovy("~/blah/params"));
+        assertFalse(RegexWithParams.isGroovy("/blah/params"));
+        assertFalse(RegexWithParams.isGroovy("/blah"));
+        assertFalse(RegexWithParams.isGroovy("~/blah"));
+        assertFalse(RegexWithParams.isGroovy("bl/ah"));
+        assertFalse(RegexWithParams.isGroovy("b~/l/ah"));
+    }
+}

--- a/src/test/java/cz/mendelu/xotradov/ResetActionTest.java
+++ b/src/test/java/cz/mendelu/xotradov/ResetActionTest.java
@@ -7,8 +7,8 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.*;
@@ -28,8 +28,8 @@ public class ResetActionTest {
     @Test
     public void doReset() throws Exception {
         ResetAction resetAction = helper.getResetAction();
-        StaplerRequest request =  Mockito.mock(StaplerRequest.class);
-        StaplerResponse response = Mockito.mock(StaplerResponse.class);
+        StaplerRequest2 request =  Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
         helper.fillQueueFor(20000);
         FreeStyleProject c = helper.createAndSchedule("C", 20000);
         helper.createAndSchedule("D", 20000);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
@@ -1,8 +1,6 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_PARAM_MODE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -98,7 +96,6 @@ public class MoveAction_doMoveByNameTest {
             StaplerResponse response = Mockito.mock(StaplerResponse.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             // Use direct Java regex syntax for Matcher::find() :
-            when(request.getParameter(ITEM_ID_PARAM_MODE)).thenReturn("regex");
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(".*(?i)[Fd](?-i).*");
 
             // Debugging aid:
@@ -154,7 +151,6 @@ public class MoveAction_doMoveByNameTest {
             StaplerResponse response = Mockito.mock(StaplerResponse.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             // Use ~/.../ syntax for Matcher::matches() :
-            when(request.getParameter(ITEM_ID_PARAM_MODE)).thenReturn("regex");
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn("~/[Fd]/i");
 
             // Debugging aid:
@@ -182,59 +178,4 @@ public class MoveAction_doMoveByNameTest {
             fail();
         }
     }
-
-    @Test
-    public void doMoveByNameManyByRegexFindNoMode() throws Exception {
-        try {
-            long maxTestTime = 10000;
-            helper.fillQueueFor(maxTestTime);
-            FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
-            FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
-            FreeStyleProject E = helper.createAndSchedule("E", maxTestTime);
-            FreeStyleProject F = helper.createAndSchedule("F", maxTestTime);
-            FreeStyleProject G = helper.createAndSchedule("G", maxTestTime);
-            FreeStyleProject H = helper.createAndSchedule("H", maxTestTime);
-
-            Queue queue = jenkinsRule.jenkins.getQueue();
-
-            assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
-            assertEquals(G.getDisplayName(), queue.getItems()[1].task.getDisplayName());
-            assertEquals(F.getDisplayName(), queue.getItems()[2].task.getDisplayName());
-            assertEquals(E.getDisplayName(), queue.getItems()[3].task.getDisplayName());
-            assertEquals(D.getDisplayName(), queue.getItems()[4].task.getDisplayName());
-            assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
-
-            List<Action> list = jenkinsRule.jenkins.getActions();
-            MoveAction moveAction = helper.getMoveAction();
-            StaplerRequest request = Mockito.mock(StaplerRequest.class);
-            StaplerResponse response = Mockito.mock(StaplerResponse.class);
-            when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
-            // Use ~/.../ syntax for Matcher::matches() :
-            when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn("~/[Fd]/i");
-
-            // Debugging aid:
-            ArrayList<String> namesBefore = new ArrayList<>();
-            for (Queue.Item item: queue.getItems())
-                namesBefore.add(item.getDisplayName());
-
-            moveAction.doMove(request, response);
-
-            // Debugging aid:
-            ArrayList<String> namesAfter = new ArrayList<>();
-            for (Queue.Item item: queue.getItems())
-                namesAfter.add(item.getDisplayName());
-
-            // We did not ask for regex mode, and the string should not have matched
-            // anything as an exact name hit, so no changes in the list:
-            assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
-            assertEquals(G.getDisplayName(), queue.getItems()[1].task.getDisplayName());
-            assertEquals(F.getDisplayName(), queue.getItems()[2].task.getDisplayName());
-            assertEquals(E.getDisplayName(), queue.getItems()[3].task.getDisplayName());
-            assertEquals(D.getDisplayName(), queue.getItems()[4].task.getDisplayName());
-            assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
 }

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
@@ -13,8 +13,8 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -52,8 +52,8 @@ public class MoveAction_doMoveByNameTest {
 
             List<Action> list = jenkinsRule.jenkins.getActions();
             MoveAction moveAction = helper.getMoveAction();
-            StaplerRequest request = Mockito.mock(StaplerRequest.class);
-            StaplerResponse response = Mockito.mock(StaplerResponse.class);
+            StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+            StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             when(request.getParameter(VIEW_NAME_PARAM_NAME)).thenReturn("all");
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(
@@ -92,8 +92,8 @@ public class MoveAction_doMoveByNameTest {
 
             List<Action> list = jenkinsRule.jenkins.getActions();
             MoveAction moveAction = helper.getMoveAction();
-            StaplerRequest request = Mockito.mock(StaplerRequest.class);
-            StaplerResponse response = Mockito.mock(StaplerResponse.class);
+            StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+            StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             // Use direct Java regex syntax for Matcher::find() :
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(".*(?i)[Fd](?-i).*");
@@ -147,8 +147,8 @@ public class MoveAction_doMoveByNameTest {
 
             List<Action> list = jenkinsRule.jenkins.getActions();
             MoveAction moveAction = helper.getMoveAction();
-            StaplerRequest request = Mockito.mock(StaplerRequest.class);
-            StaplerResponse response = Mockito.mock(StaplerResponse.class);
+            StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+            StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             // Use ~/.../ syntax for Matcher::matches() :
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn("~/[Fd]/i");

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveNewApi.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveNewApi.java
@@ -1,0 +1,269 @@
+package cz.mendelu.xotradov.test.moves;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import static cz.mendelu.xotradov.MoveAction.MOVE_TYPE_PARAM_NAME;
+import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_MODE;
+import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_NAME;
+import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_TARGET;
+import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_PARAM_NAME;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import cz.mendelu.xotradov.ItemMode;
+import cz.mendelu.xotradov.ItemTarget;
+import cz.mendelu.xotradov.MoveAction;
+import cz.mendelu.xotradov.MoveType;
+import cz.mendelu.xotradov.test.TestHelper;
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import hudson.model.Queue;
+
+public class MoveAction_doMoveNewApi {
+
+    @Rule
+    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    public final TestHelper helper = new TestHelper(jenkinsRule);
+
+    @After
+    public void waitForClean() throws Exception {
+        jenkinsRule.jenkins.getQueue().clear();
+        jenkinsRule.waitUntilNoActivity();
+    }
+
+    @Test
+    public void doClash() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(D.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn(String.valueOf(queue.getItems()[1].task.getDisplayName()));
+        when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(String.valueOf(queue.getItems()[1].task.getDisplayName()));
+
+        moveAction.doMove(request, response);
+        assertTrue(results.get(0) > 0);
+        assertTrue(results.size() == 1);
+    }
+
+    @Test
+    public void missingParam1() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(D.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn(String.valueOf(queue.getItems()[1].task.getDisplayName()));
+        moveAction.doMove(request, response);
+        assertTrue(results.get(0) > 0); //the exits and messages are chaining. initial issue, final resolution
+        assertTrue(results.get(1) > 0);
+
+        when(request.getParameter(ITEM_ID_EXT_PARAM_MODE)).thenReturn(ItemMode.EXACT.toString());
+        moveAction.doMove(request, response);
+        assertTrue(results.get(2) > 0);
+        assertTrue(results.get(3) > 0);
+    }
+
+    @Test
+    public void missingParam2() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(D.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn(String.valueOf(queue.getItems()[1].task.getDisplayName()));
+        moveAction.doMove(request, response);
+        assertTrue(results.get(0) > 0); //the exits and messages are chaining. initial issue, final resolution
+        assertTrue(results.get(1) > 0);
+
+        when(request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET)).thenReturn(new String[]{ItemTarget.DISPLAY.toString()});
+        moveAction.doMove(request, response);
+        assertTrue(results.get(2) > 0);
+        assertTrue(results.get(3) > 0);
+    }
+
+    @Test
+    public void doMoveByName() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(D.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn(String.valueOf(queue.getItems()[1].task.getDisplayName()));
+        when(request.getParameter(ITEM_ID_EXT_PARAM_MODE)).thenReturn(ItemMode.EXACT.toString());
+        when(request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET)).thenReturn(new String[]{ItemTarget.DISPLAY.toString()});
+        moveAction.doMove(request, response);
+        assertEquals(200, (int)(results.get(0)));
+
+        // We asked to move C up (lower its priority, closer to [0]), so it
+        // becomes just above whoever was at just one point lower priority (D):
+        assertEquals(C.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(D.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+    }
+
+    @Test
+    public void doMoveByNameManyByRegexMatches() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        FreeStyleProject E = helper.createAndSchedule("E", maxTestTime);
+        FreeStyleProject F = helper.createAndSchedule("F", maxTestTime);
+        FreeStyleProject G = helper.createAndSchedule("G", maxTestTime);
+        FreeStyleProject H = helper.createAndSchedule("H", maxTestTime);
+
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(G.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+        assertEquals(F.getDisplayName(), queue.getItems()[2].task.getDisplayName());
+        assertEquals(E.getDisplayName(), queue.getItems()[3].task.getDisplayName());
+        assertEquals(D.getDisplayName(), queue.getItems()[4].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_MODE)).thenReturn(ItemMode.REGEX.toString());
+        when(request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET)).thenReturn(new String[]{ItemTarget.NAME.toString()});
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn(".*(?i)[Fd](?-i).*");
+
+        moveAction.doMove(request, response);
+        assertEquals(200, (int)(results.get(0)));
+
+        assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(F.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+        assertEquals(D.getDisplayName(), queue.getItems()[2].task.getDisplayName());
+        assertEquals(G.getDisplayName(), queue.getItems()[3].task.getDisplayName());
+        assertEquals(E.getDisplayName(), queue.getItems()[4].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
+    }
+
+    @Test
+    public void doMoveByNameManyByRegexFind() throws Exception {
+        List<Integer> results = new ArrayList<>();
+        long maxTestTime = 10000;
+        helper.fillQueueFor(maxTestTime);
+        FreeStyleProject C = helper.createAndSchedule("C", maxTestTime);
+        FreeStyleProject D = helper.createAndSchedule("D", maxTestTime);
+        FreeStyleProject E = helper.createAndSchedule("E", maxTestTime);
+        FreeStyleProject F = helper.createAndSchedule("F", maxTestTime);
+        FreeStyleProject G = helper.createAndSchedule("G", maxTestTime);
+        FreeStyleProject H = helper.createAndSchedule("H", maxTestTime);
+
+        Queue queue = jenkinsRule.jenkins.getQueue();
+
+        assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(G.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+        assertEquals(F.getDisplayName(), queue.getItems()[2].task.getDisplayName());
+        assertEquals(E.getDisplayName(), queue.getItems()[3].task.getDisplayName());
+        assertEquals(D.getDisplayName(), queue.getItems()[4].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
+
+        List<Action> list = jenkinsRule.jenkins.getActions();
+        MoveAction moveAction = helper.getMoveAction();
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
+        doAnswer(invocation -> {
+            int code = invocation.getArgument(0, Integer.class);
+            results.add(code);
+            return null;
+        }).when(response).setStatus(anyInt());
+        when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
+        when(request.getParameter(ITEM_ID_EXT_PARAM_MODE)).thenReturn(ItemMode.GREGEX.toString());
+        when(request.getParameterValues(ITEM_ID_EXT_PARAM_TARGET)).thenReturn(new String[]{ItemTarget.FULLDISPLAY.toString(), ItemTarget.I.toString()});
+        when(request.getParameter(ITEM_ID_EXT_PARAM_NAME)).thenReturn("[Fd]");
+
+        moveAction.doMove(request, response);
+        assertEquals(200, (int)(results.get(0)));
+
+        assertEquals(H.getDisplayName(), queue.getItems()[0].task.getDisplayName());
+        assertEquals(F.getDisplayName(), queue.getItems()[1].task.getDisplayName());
+        assertEquals(D.getDisplayName(), queue.getItems()[2].task.getDisplayName());
+        assertEquals(G.getDisplayName(), queue.getItems()[3].task.getDisplayName());
+        assertEquals(E.getDisplayName(), queue.getItems()[4].task.getDisplayName());
+        assertEquals(C.getDisplayName(), queue.getItems()[5].task.getDisplayName());
+    }
+}

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveTest.java
@@ -11,8 +11,8 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -49,8 +49,8 @@ public class MoveAction_doMoveTest {
 
             List<Action> list = jenkinsRule.jenkins.getActions();
             MoveAction moveAction = helper.getMoveAction();
-            StaplerRequest request = Mockito.mock(StaplerRequest.class);
-            StaplerResponse response = Mockito.mock(StaplerResponse.class);
+            StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+            StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);
             when(request.getParameter(MOVE_TYPE_PARAM_NAME)).thenReturn(MoveType.UP.toString());
             when(request.getParameter(ITEM_ID_PARAM_NAME)).thenReturn(
                     String.valueOf(queue.getItems()[1].getId()));


### PR DESCRIPTION
This PR is 
* removing mandatory itemIdMode for itemId
* enabling /i for java-like regexes
* making params more versatile
* regex can search except displayName, also in fullDisplayName and jobName (via /dDn eventualy `d`,  in itemId)

Planned (maybe in future future)
* search except displayName, also in fullDisplayName and jobName   (via /Dn eventualy `d` , in itemId)
* new api with `itemIdExt` with mandatory `itemMode` of qid,exact, regex,gregex  optional "itemTarget" for display, fullDisplay, name)