### PR TITLE
SimpleQueueWidget/index.jelly: fix back the executor starvation icon

### DIFF
--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
@@ -74,11 +74,10 @@
                                         <l:breakable value="${item.displayName}"/>
                                     </a>
                                     <j:if test="${stuck}">
-                                      <td class="pane" width="16" align="center" valign="middle">
+                                        &#160;
                                         <a href="https://jenkins.io/redirect/troubleshooting/executor-starvation" target="_blank">
                                             <l:icon class="icon-hourglass icon-sm"/>
                                         </a>
-                                      </td>
                                     </j:if>
                                 </j:when>
                                 <j:otherwise>


### PR DESCRIPTION
Revert to it being added as part of text, not a new table cell

Fix a regression in #27, commented at https://github.com/jenkinsci/simple-queue-plugin/pull/27/changes#r2936649438

That recent change was wrong: in case of executor starvation, a new `td` is injected, breaking the pane markup:

<img width="340" height="487" alt="Image" src="https://github.com/user-attachments/assets/5ab44f95-8cff-4bda-87ae-972bb733adf7" />

Previously the icon was added as just another part of text; this PR restores that behavior.

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

CC @judovana @mawinter69 