### PR TITLE
Update tests from JUnit4 to JUnit5 Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,15 @@
     </developer>
   </developers>
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>simple-queue-1.4.10</tag>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   </scm>
   <properties>
     <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <dependencyManagement>

--- a/src/test/java/cz/mendelu/xotradov/DefaultSorterTest.java
+++ b/src/test/java/cz/mendelu/xotradov/DefaultSorterTest.java
@@ -1,12 +1,12 @@
 package cz.mendelu.xotradov;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import hudson.model.Queue;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class DefaultSorterTest {

--- a/src/test/java/cz/mendelu/xotradov/ResetActionTest.java
+++ b/src/test/java/cz/mendelu/xotradov/ResetActionTest.java
@@ -1,32 +1,30 @@
 package cz.mendelu.xotradov;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class ResetActionTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void doReset() throws Exception {
+    public void doReset(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         ResetAction resetAction = helper.getResetAction();
         StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
         StaplerResponse2 response = Mockito.mock(StaplerResponse2.class);

--- a/src/test/java/cz/mendelu/xotradov/SimpleQueueComparatorTest.java
+++ b/src/test/java/cz/mendelu/xotradov/SimpleQueueComparatorTest.java
@@ -1,10 +1,10 @@
 package cz.mendelu.xotradov;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import hudson.model.Queue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class SimpleQueueComparatorTest {

--- a/src/test/java/cz/mendelu/xotradov/SimpleQueueSorterTest.java
+++ b/src/test/java/cz/mendelu/xotradov/SimpleQueueSorterTest.java
@@ -1,12 +1,12 @@
 package cz.mendelu.xotradov;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import hudson.model.Queue;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class SimpleQueueSorterTest {

--- a/src/test/java/cz/mendelu/xotradov/UITest.java
+++ b/src/test/java/cz/mendelu/xotradov/UITest.java
@@ -1,29 +1,28 @@
 package cz.mendelu.xotradov;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import cz.mendelu.xotradov.test.TestHelper;
 import org.htmlunit.html.DomNode;
 import org.htmlunit.html.HtmlPage;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class UITest {
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    TestHelper helper = new TestHelper(jenkinsRule);
+    private TestHelper helper;
 
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void HoverText() throws Exception {
+    public void HoverText(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         long maxTestTime = 30000;
         helper.fillQueueFor(maxTestTime);
         helper.createAndSchedule("C", maxTestTime);
@@ -41,7 +40,8 @@ public class UITest {
     }
 
     @Test
-    public void initWidgetTest() throws Exception {
+    public void initWidgetTest(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         long maxTestTime = 30000;
         helper.fillQueueFor(maxTestTime);
         helper.createAndSchedule("C", maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/TestHelper.java
+++ b/src/test/java/cz/mendelu/xotradov/test/TestHelper.java
@@ -16,6 +16,11 @@ public class TestHelper {
     public TestHelper(JenkinsRule r) {
         this.r = r;
     }
+    
+    public void cleanup() throws Exception {
+        r.jenkins.getQueue().clear();
+        r.waitUntilNoActivity();
+    }
 
     public JenkinsRule getRule() {
         return r;

--- a/src/test/java/cz/mendelu/xotradov/test/TestHelperTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/TestHelperTest.java
@@ -1,20 +1,20 @@
 package cz.mendelu.xotradov.test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import cz.mendelu.xotradov.MoveAction;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class TestHelperTest {
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
+    private TestHelper helper;
 
     @Test
-    public void getMoveAction() {
+    public void getMoveAction(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         MoveAction moveAction = helper.getMoveAction();
         assertNotNull(moveAction);
     }

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest.java
@@ -1,18 +1,17 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import cz.mendelu.xotradov.SimpleQueueWidget;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest {
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test
-    public void widgetPresenceTest() {
+    public void widgetPresenceTest(JenkinsRule jenkinsRule) {
         assertTrue(jenkinsRule.jenkins.getPrimaryView().getWidgets().stream()
                 .anyMatch(SimpleQueueWidget.class::isInstance));
     }

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_backAndForthTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_backAndForthTest.java
@@ -1,7 +1,7 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
@@ -9,27 +9,25 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_backAndForthTest {
     public static Logger logger = Logger.getLogger(BasicTest_backAndForthTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void backAndForthTest() throws Exception {
+    public void backAndForthTest(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(20000);
         Queue queue = Queue.getInstance();
         // now can be queue filled predictably

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourCUpUpTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourCUpUpTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_fourCUpUpTest {
     public static Logger logger = Logger.getLogger(BasicTest_fourCUpUpTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void fourCUpUp() throws Exception {
+    public void fourCUpUp(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(25000);
         FreeStyleProject projectC = helper.createAndSchedule("projectC", 25000);
         FreeStyleProject projectD = helper.createAndSchedule("projectD", 25000);

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourDUpUpEDownTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourDUpUpEDownTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_fourDUpUpEDownTest {
     public static Logger logger = Logger.getLogger(BasicTest_fourDUpUpEDownTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void fourDUpUpEDown() throws Exception {
+    public void fourDUpUpEDown(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(30000);
         FreeStyleProject projectC = helper.createAndSchedule("projectC", 25000);
         FreeStyleProject projectD = helper.createAndSchedule("projectD", 25000);

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourFDownDDownCUpUpFDownTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_fourFDownDDownCUpUpFDownTest.java
@@ -1,33 +1,32 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_fourFDownDDownCUpUpFDownTest {
-    public static Logger logger = Logger.getLogger(BasicTest_fourFDownDDownCUpUpFDownTest.class.getName());
+    public static Logger logger =
+            Logger.getLogger(BasicTest_fourFDownDDownCUpUpFDownTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void fourFDownDDownCUpUpFDown() throws Exception {
+    public void fourFDownDDownCUpUpFDown(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(35000);
         FreeStyleProject projectC = helper.createAndSchedule("projectC", 35000);
         FreeStyleProject projectD = helper.createAndSchedule("projectD", 35000);

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_oneBuildSuccessTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_oneBuildSuccessTest.java
@@ -6,27 +6,25 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import hudson.model.queue.QueueTaskFuture;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_oneBuildSuccessTest {
     public static Logger logger = Logger.getLogger(BasicTest_oneBuildSuccessTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void oneBuildSuccessTest() throws Exception {
+    public void oneBuildSuccessTest(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         FreeStyleProject projectA = helper.createProject("projectA", 1000);
         QueueTaskFuture<FreeStyleBuild> futureA = helper.schedule(projectA);
         while (!Queue.getInstance().getBuildableItems().isEmpty()) {

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_twoItemsLowerUpTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_twoItemsLowerUpTest.java
@@ -1,7 +1,7 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
@@ -9,27 +9,25 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_twoItemsLowerUpTest {
     public static Logger logger = Logger.getLogger(BasicTest_twoItemsLowerUpTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void twoItemsLowerUpTest() throws Exception {
+    public void twoItemsLowerUpTest(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(20000);
         Queue queue = Queue.getInstance();
         // now can be queue filled predictably

--- a/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_twoItemsUpperDownTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/basic/BasicTest_twoItemsUpperDownTest.java
@@ -1,7 +1,7 @@
 package cz.mendelu.xotradov.test.basic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
@@ -9,27 +9,25 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class BasicTest_twoItemsUpperDownTest {
     public static Logger logger = Logger.getLogger(BasicTest_twoItemsUpperDownTest.class.getName());
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    private TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void twoItemsUpperDownTest() throws Exception {
+    public void twoItemsUpperDownTest(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         helper.fillQueueFor(20000);
         Queue queue = Queue.getInstance();
         // now can be queue filled predictably

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveByNameTest.java
@@ -3,8 +3,8 @@ package cz.mendelu.xotradov.test.moves;
 import static cz.mendelu.xotradov.MoveAction.ITEM_ID_PARAM_NAME;
 import static cz.mendelu.xotradov.MoveAction.MOVE_TYPE_PARAM_NAME;
 import static cz.mendelu.xotradov.MoveAction.VIEW_NAME_PARAM_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import cz.mendelu.xotradov.MoveAction;
@@ -15,29 +15,27 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_doMoveByNameTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void doMoveByName() throws Exception {
+    public void doMoveByName(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);
@@ -68,7 +66,8 @@ public class MoveAction_doMoveByNameTest {
     }
 
     @Test
-    public void doMoveByNameManyByRegexMatches() throws Exception {
+    public void doMoveByNameManyByRegexMatches(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);
@@ -121,7 +120,8 @@ public class MoveAction_doMoveByNameTest {
     }
 
     @Test
-    public void doMoveByNameManyByRegexFind() throws Exception {
+    public void doMoveByNameManyByRegexFind(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveNewApi.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveNewApi.java
@@ -5,8 +5,8 @@ import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_MODE;
 import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_NAME;
 import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_EXT_PARAM_TARGET;
 import static cz.mendelu.xotradov.MoveActionWorker.ITEM_ID_PARAM_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -21,29 +21,27 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_doMoveNewApi {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void doClash() throws Exception {
+    public void doClash(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);
@@ -77,7 +75,8 @@ public class MoveAction_doMoveNewApi {
     }
 
     @Test
-    public void missingParam1() throws Exception {
+    public void missingParam1(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);
@@ -113,7 +112,8 @@ public class MoveAction_doMoveNewApi {
     }
 
     @Test
-    public void missingParam2() throws Exception {
+    public void missingParam2(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);
@@ -150,7 +150,8 @@ public class MoveAction_doMoveNewApi {
     }
 
     @Test
-    public void doMoveByName() throws Exception {
+    public void doMoveByName(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);
@@ -188,7 +189,8 @@ public class MoveAction_doMoveNewApi {
     }
 
     @Test
-    public void doMoveByNameManyByRegexMatches() throws Exception {
+    public void doMoveByNameManyByRegexMatches(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);
@@ -237,7 +239,8 @@ public class MoveAction_doMoveNewApi {
     }
 
     @Test
-    public void doMoveByNameManyByRegexFind() throws Exception {
+    public void doMoveByNameManyByRegexFind(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         List<Integer> results = new ArrayList<>();
         long maxTestTime = 10000;
         helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_doMoveTest.java
@@ -2,7 +2,7 @@ package cz.mendelu.xotradov.test.moves;
 
 import static cz.mendelu.xotradov.MoveAction.ITEM_ID_PARAM_NAME;
 import static cz.mendelu.xotradov.MoveAction.MOVE_TYPE_PARAM_NAME;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import cz.mendelu.xotradov.MoveAction;
@@ -12,29 +12,27 @@ import hudson.model.Action;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_doMoveTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void doMoveByQueueItemId() throws Exception {
+    public void doMoveByQueueItemId(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_getBottomTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_getBottomTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_getBottomTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void getBottom() {
+    public void getBottom(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_getTopTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_getTopTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_getTopTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void getTop() {
+    public void getTop(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveDownFilteredTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveDownFilteredTest.java
@@ -1,8 +1,8 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import cz.mendelu.xotradov.MoveAction;
@@ -12,27 +12,25 @@ import hudson.model.Queue;
 import hudson.model.View;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_moveDownFilteredTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveDownFiltered() {
+    public void moveDownFiltered(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveDownTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveDownTest.java
@@ -1,34 +1,32 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.ArrayList;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_moveDownTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveDown() throws Exception {
+    public void moveDown(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);
@@ -48,7 +46,8 @@ public class MoveAction_moveDownTest {
     }
 
     @Test
-    public void moveDownMany() throws Exception {
+    public void moveDownMany(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToBottomFilteredTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToBottomFilteredTest.java
@@ -1,7 +1,7 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import cz.mendelu.xotradov.MoveAction;
@@ -11,27 +11,25 @@ import hudson.model.Queue;
 import hudson.model.View;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_moveToBottomFilteredTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveToBottomFiltered() {
+    public void moveToBottomFiltered(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToBottomTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToBottomTest.java
@@ -1,32 +1,30 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_moveToBottomTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveToBottom() {
+    public void moveToBottom(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);
@@ -65,7 +63,8 @@ public class MoveAction_moveToBottomTest {
     }
 
     @Test
-    public void moveToBottomMany() {
+    public void moveToBottomMany(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToTopTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveToTopTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
 import java.util.ArrayList;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_moveToTopTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveToTop() {
+    public void moveToTop(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);
@@ -46,7 +44,8 @@ public class MoveAction_moveToTopTest {
     }
 
     @Test
-    public void moveToTopMany() {
+    public void moveToTopMany(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveUpFilteredTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveUpFilteredTest.java
@@ -1,8 +1,8 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import cz.mendelu.xotradov.MoveAction;
@@ -12,27 +12,25 @@ import hudson.model.Queue;
 import hudson.model.View;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.Mockito;
 
+@WithJenkins
 public class MoveAction_moveUpFilteredTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveUpFiltered() {
+    public void moveUpFiltered(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 20000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveUpTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_moveUpTest.java
@@ -1,33 +1,31 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_moveUpTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void moveUp() throws Exception {
+    public void moveUp(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);
@@ -46,7 +44,8 @@ public class MoveAction_moveUpTest {
     }
 
     @Test
-    public void moveUpMany() throws Exception {
+    public void moveUpMany(JenkinsRule jenkinsRule) throws Exception {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 10000;
             helper.fillQueueFor(maxTestTime);

--- a/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_putAOnTopOfBTest.java
+++ b/src/test/java/cz/mendelu/xotradov/test/moves/MoveAction_putAOnTopOfBTest.java
@@ -1,32 +1,30 @@
 package cz.mendelu.xotradov.test.moves;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import cz.mendelu.xotradov.MoveAction;
 import cz.mendelu.xotradov.test.TestHelper;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+@WithJenkins
 public class MoveAction_putAOnTopOfBTest {
 
-    @Rule
-    public final JenkinsRule jenkinsRule = new JenkinsRule();
+    private TestHelper helper;
 
-    public final TestHelper helper = new TestHelper(jenkinsRule);
-
-    @After
+    @AfterEach
     public void waitForClean() throws Exception {
-        jenkinsRule.jenkins.getQueue().clear();
-        jenkinsRule.waitUntilNoActivity();
+        helper.cleanup();
     }
 
     @Test
-    public void putAOnTopOfB() {
+    public void putAOnTopOfB(JenkinsRule jenkinsRule) {
+        helper = new TestHelper(jenkinsRule);
         try {
             long maxTestTime = 30000;
             helper.fillQueueFor(maxTestTime);


### PR DESCRIPTION
Also stop complaining about "junit vintage" getting used.

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Awaiting ci.j.io to confirm idempotency of changes for the casual on-looker, but no longer report this:
```
13:08:22  [INFO] -------------------------------------------------------
13:08:22  [INFO]  T E S T S
13:08:22  [INFO] -------------------------------------------------------

13:08:23  Mar 15, 2026 12:08:22 PM org.junit.platform.launcher.core.DiscoveryIssueNotifier logIssues
13:08:23  INFO: TestEngine with ID 'junit-vintage' encountered a non-critical issue during test discovery:
13:08:23  
13:08:23  (1) [INFO] The JUnit Vintage engine is deprecated and should only be used temporarily while migrating tests to JUnit Jupiter or another testing framework with native JUnit Platform support.

13:08:23  Mar 15, 2026 12:08:23 PM org.junit.platform.launcher.core.DiscoveryIssueNotifier logIssues
...
```

NOTE: Build logs also report several hits of this:
```
13:08:20  [WARNING] unknown enum constant javax.annotation.meta.When.ALWAYS
13:08:20  [WARNING] unknown enum constant javax.annotation.meta.When.MAYBE
13:08:20    reason: class file for javax.annotation.meta.When not found
```
...but Internet lore says that some dependency must have been compiled with JSR-305 (which Jenkins plugins aim to remove per https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/ effort documentation), so these warnings should go away when those components are identified and updated via parent BOM.

DISCLAIMER: Repetitive pattern replacement was augmented by AI (IntelliJ Junie) and manually revised to make sense, and it indeed does seem to not break the intention of all those tests.