### PR TITLE
Fix back blank space for sorting buttons of not-yet-buildable items

### DIFF
--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
@@ -87,8 +87,8 @@
                         </td>
                         <!-- start of normal button section-->
                         <j:set var="buildable" value="${item.isBuildable()}"/>
-                        <j:if test="${buildable and h.hasPermission(app.MANAGE)}">
-                            <td class="pane" align="center" valign="middle">
+                        <td class="pane" align="center" valign="middle">
+                            <j:if test="${buildable and h.hasPermission(app.MANAGE)}">
                               <div class="simple-queue-buttons">
                                   <j:if test="${filtered}">
                                       <a href="#" class="simple-move-link" data-move-type="TOP" data-item-id="${item.id}"
@@ -125,8 +125,8 @@
                                       </a>
                                   </j:if>
                               </div>
-                            </td>
-                        </j:if>
+                            </j:if>
+                        </td>
                         <td class="pane" align="center" valign="middle">
                             <j:if test="${item.hasCancelPermission()}">
                                 <div class="simple-queue-buttons">


### PR DESCRIPTION
Recent PR #27 made the `<td>` with buttons conditional, so not all table rows have the same amount of cells. This PR proposes to switch around `td` and `j:if` lines, so the cell is always present but sometimes empty.

Similar to #30 in essence.

CC @mawinter69 just in case

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Example of broken markup rendering:
<img width="332" height="351" alt="image" src="https://github.com/user-attachments/assets/14048310-f020-4e13-a761-b8a566e5ec63" />

