### PR TITLE
Don't escape tooltip

### DIFF
--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
@@ -69,7 +69,7 @@
                             <j:choose>
                                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                                     <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr"
-                                       tooltip="${h.escape(item.causesDescription)}${h.escape(item.why)}${h.escape(item.params)}&lt;br&gt;Waiting for (${item.getInQueueForString()})"
+                                       tooltip="${item.causesDescription} ${item.why} ${item.params} \n Waiting for (${item.inQueueForString})"
                                        data-tooltip-append-to-parent="true">
                                         <l:breakable value="${item.displayName}"/>
                                     </a>


### PR DESCRIPTION
The tooltip in the queue is plain text not html, so there is no need to escape things.

Before:
The parameter is actually `<img alert('1')/>`
<img width="436" height="255" alt="image" src="https://github.com/user-attachments/assets/a59cb16d-5c18-4667-b4a8-d8cb1f9d2108" />

After:
<img width="423" height="310" alt="image" src="https://github.com/user-attachments/assets/091863ad-f178-4eca-892b-2e3dc2ef029c" />

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed