### PR TITLE
Align starvation icon to the right

### DIFF
--- a/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
+++ b/src/main/resources/cz/mendelu/xotradov/SimpleQueueWidget/index.jelly
@@ -66,6 +66,7 @@
                     <tr>
                         <td class="pane" width="100%" style="white-space: normal;">
                             <j:set var="stuck" value="${item.isStuck()}"/>
+                            <j:set var="stuckContent" value=""/>
                             <j:choose>
                                 <j:when test="${h.hasPermission(item.task,item.task.READ)}">
                                     <a href="${rootURL}/${item.task.url}" class="model-link inside tl-tr"
@@ -74,16 +75,20 @@
                                         <l:breakable value="${item.displayName}"/>
                                     </a>
                                     <j:if test="${stuck}">
-                                        &#160;
-                                        <a href="https://jenkins.io/redirect/troubleshooting/executor-starvation" target="_blank">
-                                            <l:icon class="icon-hourglass icon-sm"/>
-                                        </a>
+                                        <j:set var="stuckContent">
+                                            <a href="https://jenkins.io/redirect/troubleshooting/executor-starvation" target="_blank">
+                                                <l:icon class="icon-hourglass icon-sm"/>
+                                            </a>
+                                        </j:set>
                                     </j:if>
                                 </j:when>
                                 <j:otherwise>
                                     <span>${%Unknown Task}</span>
                                 </j:otherwise>
                             </j:choose>
+                        </td>
+                        <td class="pane" align="center" valign="middle">
+                          <j:out value="${stuckContent}"/>
                         </td>
                         <!-- start of normal button section-->
                         <j:set var="buildable" value="${item.isBuildable()}"/>


### PR DESCRIPTION
Always include a `td` but only include the icon when the item is stuck.

Before:
<img width="428" height="270" alt="image" src="https://github.com/user-attachments/assets/3fc69549-c6d3-49f5-bc19-ade41ed9fca7" />

After:
<img width="426" height="260" alt="image" src="https://github.com/user-attachments/assets/50f6556c-8156-43a3-8fbb-82b028c05a18" />


### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed