### PR TITLE
SimpleQueueSorter, SimpleQueueComparator: skip work in sortBuildableItems() if nothing in the plugin has changed since last round

### DIFF
--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueComparator.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueComparator.java
@@ -14,6 +14,10 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     private static Logger logger = Logger.getLogger(SimpleQueueComparator.class.getName());
     private Hashtable<Long, List<Long>> moveDesires = new Hashtable<>();
 
+    /** This flag indicates if any changes were made to the desires,
+     *  so whether SimpleQueueSorter should re-run or may skip work. */
+    private boolean changedDesires = true;
+
     private static class SimpleQueueComparatorHolder {
         static final SimpleQueueComparator INSTANCE = new SimpleQueueComparator();
     }
@@ -25,6 +29,7 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     public boolean hasDesiresFor(long key) {
         return moveDesires.containsKey(key);
     }
+
     /**
      * @return -1 when first is more important, 1 when second is more important, default 0
      */
@@ -48,44 +53,73 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     }
 
     /**
-     * Add desire of order relationship between two items. If is present vice versa relation, it is deleted.
+     * Add desire of order relationship between two items.
+     * If is present vice versa relation, it is deleted.
      * @param longA Id of desired more important item
      * @param longB Id of less important Queue.Item
      */
     public void addDesire(long longA, long longB) {
-        List<Long> bList;
-        if (!moveDesires.containsKey(longA)) {
-            bList = new ArrayList<>();
-            moveDesires.put(longA, bList);
-        } else {
-            bList = moveDesires.get(longA);
-        }
-        if (bList != null) {
-            if (bList.isEmpty()) {
-                bList.add(longB);
+        synchronized (this) {
+            List<Long> bList;
+            if (!moveDesires.containsKey(longA)) {
+                bList = new ArrayList<>();
+                moveDesires.put(longA, bList);
             } else {
-                if (!bList.contains(longB)) {
+                bList = moveDesires.get(longA);
+            }
+            if (bList != null) {
+                if (bList.isEmpty()) {
                     bList.add(longB);
+                } else {
+                    if (!bList.contains(longB)) {
+                        bList.add(longB);
+                    }
+                }
+                // Cleaning of previous order
+                List<Long> aList = moveDesires.get(longB);
+                if (aList != null && aList.contains(longA)) {
+                    aList.remove(longA);
+                    if (aList.isEmpty()) {
+                        moveDesires.remove(longB);
+                    }
                 }
             }
-            // Cleaning of previous order
-            List<Long> aList = moveDesires.get(longB);
-            if (aList != null && aList.contains(longA)) {
-                aList.remove(longA);
-                if (aList.isEmpty()) {
-                    moveDesires.remove(longB);
-                }
-            }
+            changedDesires = true;
         }
     }
 
     @VisibleForTesting
     public void removeDesireOfKey(long id) {
-        moveDesires.remove(id);
+        synchronized (this) {
+            moveDesires.remove(id);
+            changedDesires = true;
+        }
     }
 
     @VisibleForTesting
     public void resetDesires() {
-        moveDesires.clear();
+        synchronized (this) {
+            moveDesires.clear();
+            changedDesires = true;
+        }
+    }
+
+    /** Signal to {@link SimpleQueueSorter} that some changes
+     *  were made to the desires since the flag was last reset.
+     *  @return true if changes were made, false otherwise
+     * @see SimpleQueueSorter
+     * @see #resetChangedDesires()
+     */
+    public boolean hasChangedDesires() {
+        return changedDesires;
+    }
+
+    /** Reset the flag that indicates that changes were made
+     *  to the desires. Intended to be called by
+     *  {@link SimpleQueueSorter} after it re-processes the
+     *  actual queue.
+     */
+    public void resetChangedDesires() {
+        changedDesires = false;
     }
 }

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueComparator.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueComparator.java
@@ -14,6 +14,10 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     private static Logger logger = Logger.getLogger(SimpleQueueComparator.class.getName());
     private Hashtable<Long, List<Long>> moveDesires = new Hashtable<>();
 
+    /** This flag indicates if any changes were made to the desires,
+     *  so whether SimpleQueueSorter should re-run or may skip work. */
+    private boolean changedDesires = true;
+
     private static class SimpleQueueComparatorHolder {
         static final SimpleQueueComparator INSTANCE = new SimpleQueueComparator();
     }
@@ -25,6 +29,7 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     public boolean hasDesiresFor(long key) {
         return moveDesires.containsKey(key);
     }
+
     /**
      * @return -1 when first is more important, 1 when second is more important, default 0
      */
@@ -48,7 +53,8 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
     }
 
     /**
-     * Add desire of order relationship between two items. If is present vice versa relation, it is deleted.
+     * Add desire of order relationship between two items.
+     * If is present vice versa relation, it is deleted.
      * @param longA Id of desired more important item
      * @param longB Id of less important Queue.Item
      */
@@ -77,15 +83,37 @@ public class SimpleQueueComparator implements Comparator<Queue.BuildableItem> {
                 }
             }
         }
+        changedDesires = true;
     }
 
     @VisibleForTesting
     public void removeDesireOfKey(long id) {
         moveDesires.remove(id);
+        changedDesires = true;
     }
 
     @VisibleForTesting
     public void resetDesires() {
         moveDesires.clear();
+        changedDesires = true;
+    }
+
+    /** Signal to {@link SimpleQueueSorter} that some changes
+     *  were made to the desires since the flag was last reset.
+     *  @return true if changes were made, false otherwise
+     * @see SimpleQueueSorter
+     * @see #resetChangedDesires()
+     */
+    public boolean hasChangedDesires() {
+        return changedDesires;
+    }
+
+    /** Reset the flag that indicates that changes were made
+     *  to the desires. Intended to be called by
+     *  {@link SimpleQueueSorter} after it re-processes the
+     *  actual queue.
+     */
+    public void resetChangedDesires() {
+        changedDesires = false;
     }
 }

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueSorter.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueSorter.java
@@ -2,6 +2,8 @@ package cz.mendelu.xotradov;
 
 import hudson.model.Queue;
 import hudson.model.queue.QueueSorter;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -15,6 +17,7 @@ public class SimpleQueueSorter extends QueueSorter {
     private static Logger logger = Logger.getLogger(SimpleQueueSorter.class.getName());
     private final QueueSorter originalQueueSorter;
     private final SimpleQueueComparator simpleQueueComparator;
+    private final transient List<Queue.BuildableItem> listPrevious = new ArrayList<>();
 
     public SimpleQueueSorter(QueueSorter originalQueueSorter) {
         this.originalQueueSorter = originalQueueSorter;
@@ -23,36 +26,47 @@ public class SimpleQueueSorter extends QueueSorter {
 
     @Override
     public void sortBuildableItems(List<Queue.BuildableItem> list) {
-        if (this.originalQueueSorter != null) {
-            // Note: if DefaultSorter (usually is), we pre-sort by timestamps
-            // and then follow up below with desires for relative priorities
-            // of specific items.
-            this.originalQueueSorter.sortBuildableItems(list);
+        synchronized (simpleQueueComparator) {
+            // Avoid unnecessary sorting if nothing changed since last round:
+            // same items in same order
+            if (!(simpleQueueComparator.hasChangedDesires()) && list.equals(listPrevious)) return;
+
+            if (this.originalQueueSorter != null) {
+                // Note: if DefaultSorter (usually is), we pre-sort by timestamps
+                // and then follow up below with desires for relative priorities
+                // of specific items.
+                this.originalQueueSorter.sortBuildableItems(list);
+            }
+
+            // Note: the sort() method does not compare everyone to everyone,
+            // it passes the list comparing nearby couples and only steps back
+            // a bit if some two (neighboring!) entries were swapped. Example:
+            //   * list start: [C]3 [A]4 [D]5 [B]6 [E]7
+            //   * comparator desires, one: 7 (more important) => [6, 4]
+            //     so E should move to the middle of the list, A and B to the right?..
+            //   * comparisons as traced in debugger (steps into the compare()
+            //     method and its two args):
+            //     * Round 1, starting with C A D B E:
+            //       * A, C => 0
+            //       * D, A => 0
+            //       * B, D => 0
+            //       * E, B => -1 (E more important)
+            //     * List swapped (E vs B)
+            //     * Round 2, proceeding with C A D E B
+            //       * E, D => 0
+            //       * E, B => -1
+            //     * No more swapping (correct order of E vs B already),
+            //     * List remains C A D E B
+            //   * Note that [E]7 was never compared to A[4], they were too far away
+            //     so the expected desire for C D E A B (nor C D E B A technically)
+            //     was not fulfilled UNTIL desires for A  vs. D and A vs. E got defined,
+            //     and the move*() methods for arrays got more complex that initially.
+            Collections.sort(list, simpleQueueComparator);
+            simpleQueueComparator.resetChangedDesires();
+
+            listPrevious.clear();
+            listPrevious.addAll(list);
         }
-        // Note: the sort() method does not compare everyone to everyone,
-        // it passes the list comparing nearby couples and only steps back
-        // a bit if some two (neighboring!) entries were swapped. Example:
-        //   * list start: [C]3 [A]4 [D]5 [B]6 [E]7
-        //   * comparator desires, one: 7 (more important) => [6, 4]
-        //     so E should move to the middle of the list, A and B to the right?..
-        //   * comparisons as traced in debugger (steps into the compare()
-        //     method and its two args):
-        //     * Round 1, starting with C A D B E:
-        //       * A, C => 0
-        //       * D, A => 0
-        //       * B, D => 0
-        //       * E, B => -1 (E more important)
-        //     * List swapped (E vs B)
-        //     * Round 2, proceeding with C A D E B
-        //       * E, D => 0
-        //       * E, B => -1
-        //     * No more swapping (correct order of E vs B already),
-        //     * List remains C A D E B
-        //   * Note that [E]7 was never compared to A[4], they were too far away
-        //     so the expected desire for C D E A B (nor C D E B A technically)
-        //     was not fulfilled UNTIL desires for A  vs. D and A vs. E got defined,
-        //     and the move*() methods for arrays got more complex that initially.
-        Collections.sort(list, simpleQueueComparator);
     }
 
     public SimpleQueueComparator getSimpleQueueComparator() {
@@ -60,6 +74,9 @@ public class SimpleQueueSorter extends QueueSorter {
     }
 
     void reset() {
+        // NOTE: This logic is not "synchronized(simpleQueueComparator)"
+        // to avoid deadlocks with methods it calls which sync on that.
+        listPrevious.clear();
         simpleQueueComparator.resetDesires();
         sortBuildableItems(Jenkins.get().getQueue().getBuildableItems());
         Queue.getInstance().maintain();

--- a/src/main/java/cz/mendelu/xotradov/SimpleQueueSorter.java
+++ b/src/main/java/cz/mendelu/xotradov/SimpleQueueSorter.java
@@ -2,6 +2,8 @@ package cz.mendelu.xotradov;
 
 import hudson.model.Queue;
 import hudson.model.queue.QueueSorter;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
@@ -15,6 +17,7 @@ public class SimpleQueueSorter extends QueueSorter {
     private static Logger logger = Logger.getLogger(SimpleQueueSorter.class.getName());
     private final QueueSorter originalQueueSorter;
     private final SimpleQueueComparator simpleQueueComparator;
+    private final transient List<Queue.BuildableItem> listPrevious = new ArrayList<>();
 
     public SimpleQueueSorter(QueueSorter originalQueueSorter) {
         this.originalQueueSorter = originalQueueSorter;
@@ -23,12 +26,17 @@ public class SimpleQueueSorter extends QueueSorter {
 
     @Override
     public void sortBuildableItems(List<Queue.BuildableItem> list) {
+        // Avoid unnecessary sorting if nothing changed since last round:
+        // same items in same order
+        if (!(simpleQueueComparator.hasChangedDesires()) && list.equals(listPrevious)) return;
+
         if (this.originalQueueSorter != null) {
             // Note: if DefaultSorter (usually is), we pre-sort by timestamps
             // and then follow up below with desires for relative priorities
             // of specific items.
             this.originalQueueSorter.sortBuildableItems(list);
         }
+
         // Note: the sort() method does not compare everyone to everyone,
         // it passes the list comparing nearby couples and only steps back
         // a bit if some two (neighboring!) entries were swapped. Example:
@@ -53,6 +61,10 @@ public class SimpleQueueSorter extends QueueSorter {
         //     was not fulfilled UNTIL desires for A  vs. D and A vs. E got defined,
         //     and the move*() methods for arrays got more complex that initially.
         Collections.sort(list, simpleQueueComparator);
+        simpleQueueComparator.resetChangedDesires();
+
+        listPrevious.clear();
+        listPrevious.addAll(list);
     }
 
     public SimpleQueueComparator getSimpleQueueComparator() {
@@ -60,6 +72,9 @@ public class SimpleQueueSorter extends QueueSorter {
     }
 
     void reset() {
+        // NOTE: This logic is not "synchronized(simpleQueueComparator)"
+        // to avoid deadlocks with methods it calls which sync on that.
+        listPrevious.clear();
         simpleQueueComparator.resetDesires();
         sortBuildableItems(Jenkins.get().getQueue().getBuildableItems());
         Queue.getInstance().maintain();


### PR DESCRIPTION
I found that my CI server (with several hundred queue items) was lagging lately, although it was not really doing much, just eating a CPU core with JVM and occasionally making build agents busy. Much of the time they were idling, despite the pressure of the queue. Builds that previously took ~7-10 hours to pass the big matrix now did not complete after a day. Possibly a regression in some plugin or core change, as a few upgrades were applied during the month.

Looking at threads found that it was spinning in this:
```
AtmostOneTaskExecutor[Periodic Jenkins queue maintenance] [#2029]
java.base@21.0.5/java.lang.Class.forName0(Native Method)
java.base@21.0.5/java.lang.Class.forName(Class.java:534)
java.base@21.0.5/java.lang.Class.forName(Class.java:513)
java.xml@21.0.5/javax.xml.transform.FactoryFinder.getProviderClass(FactoryFinder.java:96)
java.xml@21.0.5/javax.xml.transform.FactoryFinder.newInstance(FactoryFinder.java:151)
java.xml@21.0.5/javax.xml.transform.FactoryFinder.find(FactoryFinder.java:222)
java.xml@21.0.5/javax.xml.transform.TransformerFactory.newInstance(TransformerFactory.java:86)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryBaseAction.<init>(JobConfigHistoryBaseAction.java:95)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryProjectAction.<init>(JobConfigHistoryProjectAction.java:79)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryActionFactory.createFor(JobConfigHistoryActionFactory.java:64)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryActionFactory.createFor(JobConfigHistoryActionFactory.java:42)
hudson.model.Actionable.createFor(Actionable.java:118)
hudson.model.Actionable.getAction(Actionable.java:336)
PluginClassLoader for branch-api//jenkins.branch.MultiBranchProject.getDisplayName(MultiBranchProject.java:885)
hudson.model.AbstractItem.getFullDisplayName(AbstractItem.java:487)
hudson.model.AbstractItem.getFullDisplayName(AbstractItem.java:485)
hudson.model.Run.getFullDisplayName(Run.java:747)
PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getDisplayName(ExecutorStepExecution.java:764)
PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getFullDisplayName(ExecutorStepExecution.java:783)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.GetNameOfItem(ConfigurableQueueSorter.java:49)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.LogNoPreference(ConfigurableQueueSorter.java:43)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.compare(ConfigurableQueueSorter.java:78)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.compare(ConfigurableQueueSorter.java:17)
java.base@21.0.5/java.util.TimSort.countRunAndMakeAscending(TimSort.java:360)
java.base@21.0.5/java.util.TimSort.sort(TimSort.java:234)
java.base@21.0.5/java.util.Arrays.sort(Arrays.java:1308)
java.base@21.0.5/java.util.ArrayList.sort(ArrayList.java:1804)
hudson.model.queue.AbstractQueueSorterImpl.sortBuildableItems(AbstractQueueSorterImpl.java:19)
PluginClassLoader for simple-queue//cz.mendelu.xotradov.SimpleQueueSorter.sortBuildableItems(SimpleQueueSorter.java:30)
hudson.model.Queue.maintain(Queue.java:1730)
hudson.model.Queue$1.call(Queue.java:339)
hudson.model.Queue$1.call(Queue.java:336)
jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:109)
jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:99)
jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
java.base@21.0.5/java.util.concurrent.FutureTask.run(FutureTask.java:317)
hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
java.base@21.0.5/java.lang.Thread.runWith(Thread.java:1596)
java.base@21.0.5/java.lang.Thread.run(Thread.java:1583)
```

Or on another occasion this (with longer trace in one part):
```
AtmostOneTaskExecutor[Periodic Jenkins queue maintenance] [#2061]
java.base@21.0.5/sun.security.util.SignatureFileVerifier.updateSigners(SignatureFileVerifier.java:825)
java.base@21.0.5/sun.security.util.SignatureFileVerifier.processImpl(SignatureFileVerifier.java:359)
java.base@21.0.5/sun.security.util.SignatureFileVerifier.process(SignatureFileVerifier.java:282)
java.base@21.0.5/java.util.jar.JarVerifier.processEntry(JarVerifier.java:320)
java.base@21.0.5/java.util.jar.JarVerifier.update(JarVerifier.java:232)
java.base@21.0.5/java.util.jar.JarFile.initializeVerifier(JarFile.java:760)
java.base@21.0.5/java.util.jar.JarFile.getInputStream(JarFile.java:858)
java.base@21.0.5/sun.net.www.protocol.jar.JarURLConnection.getInputStream(JarURLConnection.java:166)
java.base@21.0.5/java.util.ServiceLoader$LazyClassPathLookupIterator.parse(ServiceLoader.java:1172)
java.base@21.0.5/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1213)
java.base@21.0.5/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1228)
java.base@21.0.5/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
java.base@21.0.5/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
java.base@21.0.5/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
java.xml@21.0.5/javax.xml.transform.FactoryFinder$1.run(FactoryFinder.java:241)
java.base@21.0.5/java.security.AccessController.executePrivileged(AccessController.java:778)
java.base@21.0.5/java.security.AccessController.doPrivileged(AccessController.java:319)
java.xml@21.0.5/javax.xml.transform.FactoryFinder.findServiceProvider(FactoryFinder.java:237)
java.xml@21.0.5/javax.xml.transform.FactoryFinder.find(FactoryFinder.java:212)
java.xml@21.0.5/javax.xml.transform.TransformerFactory.newInstance(TransformerFactory.java:86)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryBaseAction.<init>(JobConfigHistoryBaseAction.java:95)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryProjectAction.<init>(JobConfigHistoryProjectAction.java:79)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryActionFactory.createFor(JobConfigHistoryActionFactory.java:64)
PluginClassLoader for jobConfigHistory//hudson.plugins.jobConfigHistory.JobConfigHistoryActionFactory.createFor(JobConfigHistoryActionFactory.java:42)
hudson.model.Actionable.createFor(Actionable.java:118)
hudson.model.Actionable.getAction(Actionable.java:336)
PluginClassLoader for branch-api//jenkins.branch.MultiBranchProject.getDisplayName(MultiBranchProject.java:885)
hudson.model.AbstractItem.getFullDisplayName(AbstractItem.java:487)
hudson.model.AbstractItem.getFullDisplayName(AbstractItem.java:485)
hudson.model.Run.getFullDisplayName(Run.java:747)
PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getDisplayName(ExecutorStepExecution.java:764)
PluginClassLoader for workflow-durable-task-step//org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution$PlaceholderTask.getFullDisplayName(ExecutorStepExecution.java:783)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.GetNameOfItem(ConfigurableQueueSorter.java:50)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.LogNoPreference(ConfigurableQueueSorter.java:43)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.compare(ConfigurableQueueSorter.java:78)
PluginClassLoader for fast-track//nl.arnom.jenkins.fasttrack.ConfigurableQueueSorter.compare(ConfigurableQueueSorter.java:17)
java.base@21.0.5/java.util.TimSort.countRunAndMakeAscending(TimSort.java:360)
java.base@21.0.5/java.util.TimSort.sort(TimSort.java:234)
java.base@21.0.5/java.util.Arrays.sort(Arrays.java:1308)
java.base@21.0.5/java.util.ArrayList.sort(ArrayList.java:1804)
hudson.model.queue.AbstractQueueSorterImpl.sortBuildableItems(AbstractQueueSorterImpl.java:19)
PluginClassLoader for simple-queue//cz.mendelu.xotradov.SimpleQueueSorter.sortBuildableItems(SimpleQueueSorter.java:30)
hudson.model.Queue.maintain(Queue.java:1730)
hudson.model.Queue$1.call(Queue.java:339)
hudson.model.Queue$1.call(Queue.java:336)
jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:109)
jenkins.util.AtmostOneTaskExecutor$1.call(AtmostOneTaskExecutor.java:99)
jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:80)
java.base@21.0.5/java.util.concurrent.FutureTask.run(FutureTask.java:317)
hudson.remoting.AtmostOneThreadExecutor$Worker.run(AtmostOneThreadExecutor.java:121)
java.base@21.0.5/java.lang.Thread.runWith(Thread.java:1596)
java.base@21.0.5/java.lang.Thread.run(Thread.java:1583)
```

Either way, per suggestions of the AI I fed those traces to, one part of tackling this was to try and get rid of other queue management plugins (disablet fasstrack for now), but the pathology it pointed out seems shared by both - and is ingrained to how/why we sort at least here.

TLDR: Doing `get*DisplayName()` turns out to be CPU and I/O intensive, doing so in a loop causes a thermal meltdown for the CPU.

In its own words:

> That stack trace is actually very revealing—more than it might look at first glance. This isn’t a generic “Jenkins is busy” situation; it’s a pathological interaction between queue sorting and plugins doing expensive work during display name resolution.
> 
> Let’s unpack what’s really happening.
> 
> 🔥 What your hot thread is doing
> 
> The key parts of your stack:
> 
> * `Queue.maintain()` → runs periodically
> * sorting via:
>   * fast-track plugin (`ConfigurableQueueSorter.compare`)
>   * also simple-queue plugin (!)
> * during sorting it calls:
>   * `getDisplayName()` → `getFullDisplayName()` → `Run.getFullDisplayName()`
> * which triggers:
>   * jobConfigHistory plugin creating actions
> * which does:
>   * `TransformerFactory.newInstance()` → XML factory lookup via reflection (`Class.forName`)
> 
> So every comparison during sorting is:
> → resolving display names
> → instantiating plugin actions
> → doing XML factory discovery (!)
> 
> …and sorting is `O(n log n)` comparisons.
> 
> 💥 Why this melts a CPU core
> 
> You’ve got a perfect storm:
> 
> 1. Expensive comparator (this is the root bug)
> 
> Your queue sorter plugins:
> 
> * fast-track plugin
> * simple-queue plugin
> 
> are calling display name resolution inside `compare()`.
> 
> That’s a classic performance anti-pattern:
> 
> > Comparators must be pure and cheap—no I/O, no object creation, no plugin calls.
> 
> 2. Display name resolution is NOT cheap
> 
> This call chain:
> 
> `getDisplayName → getFullDisplayName → Run.getFullDisplayName`
> 
> triggers:
> 
> * lazy action creation (`Actionable.createFor`)
> * plugin hooks (like `jobConfigHistory`)
> 
> So something that should be a string lookup becomes:
> 
> * plugin instantiation
> * XML factory lookup
> * classloading
>
> 3. XML factory lookup is surprisingly expensive
> 
> This line:
> 
> `TransformerFactory.newInstance()`
> 
> does:
> 
> * service loader lookup
> * classpath scanning
> * reflection (`Class.forName`)
> 
> Doing that repeatedly in a tight loop = 🔥 CPU burn.
> 
> 4. Sorting amplifies everything
> 
> Sorting N items:
> 
> * ~N log N comparisons
> * each comparison triggers all of the above
> 
> If your queue has, say, 200 items:
> → thousands of expensive calls per maintenance cycle
> → repeated frequently
> → one thread stuck at 100% of a core
> 
> 🚨 Extra red flag: TWO queue sorters active
> 
> Your stack shows both:
> 
> * fast-track sorter
> * simple-queue sorter
> 
> That’s suspicious. Jenkins normally uses one queue sorter.
> 
> This suggests:
> 
> * conflicting plugins
> * or layered sorting (worse performance)
>
> ✅ What to do (in order of impact)
> 1. Remove or disable queue sorter plugins (highly recommended)
> 
> Start with:
> 
> * disable fast-track plugin
> * disable simple-queue plugin
> 
> Restart Jenkins and observe CPU.
> 
> 👉 This alone will likely fix the issue.
> 
> 2. Disable or test without jobConfigHistory
> 
> The plugin:
> 
> * jobConfigHistory plugin
> 
> is being invoked during display name resolution (which is already suspicious).
> 
> Try:
> 
> * temporarily disabling it
> * or upgrading to latest version
>
> 3. Reduce queue size / churn
> 
> Even with fixes, large queues amplify issues:
> 
> * many multibranch jobs
> * lots of queued pipeline steps
> 
> Check:
> 
> * are items stuck?
> * is something re-queuing aggressively?
>
> 4. Confirm with profiling (optional but validating)
> 
> If you run Java Flight Recorder, you’ll likely see:
> 
> * `TransformerFactory.newInstance`
> * `Class.forName`
> * plugin constructors
> 
> dominating CPU time.
> 
> 🧠 Root cause (in one sentence)
> 
> A queue sorting plugin is using `getDisplayName()` inside its comparator, which triggers heavy plugin logic (including XML factory instantiation), and this is executed thousands of times per queue maintenance cycle.
> 
> 💡 Long-term fix (if you keep a sorter plugin)
> 
> If you must use a custom sorter:
> 
> * Ensure it uses:
>   * cached values
>   * lightweight identifiers (e.g. `Queue.Item.id`, not display names)
> * Never call:
>   * `getDisplayName()`
>   * `getFullDisplayName()`
>   * anything that can trigger `Actionable.createFor`
>
> 👍 Bottom line
> 
> This is not a JVM issue, not a GC issue, and not a mysterious loop.
> 
> It’s:
> 
> A bad comparator + expensive plugin side effects + sorting amplification
> 

This PR takes a bite at suggestions (well, most of them are not relevant for how that controller is set up and how the jenkins-dynamarix spawns the tons of queue items): the reasonable idea was to cache something and skip work.

That's what the few lines proposed here do: remember the previous list we returned, and track if we set up any desires since then, and quickly return from `sortBuildableItems()` if there is nothing for us to do (same list items, same order, no new desires).

This seems to work in practice, but I've just deployed it. At least sorting via buttons does still work, the controller does not have any thread dominating a CPU core, and remote agents are occupied.

To err on the safe side, I added `synchronized` around code working with the `listPrev` and `changedDesires`, not fully sure I did not fool up in that, but so far nothing seems to have dead-locked.

The plugin also used to call an `originalQueueSorter` if available (to prepare the list for its own sorting per "desires") - now this is also bypassed if THIS plugin has nothing to do. I am not sure if this was a correct choice either, feel free to overrule.

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

I expect to keep this running on the controller that had problems previously, to see if some regression pops out (e.g. if I return competing queue plugins). If nothing explodes nor looks bad to reviewers, maybe this can be merged in 2-4 weeks.